### PR TITLE
update running standalone etcd link

### DIFF
--- a/run-with-mesosphere.md
+++ b/run-with-mesosphere.md
@@ -67,7 +67,7 @@ This section assumes that Portworx will be installed on a set of homogeneously c
 The pre-requisites for installing Portworx through Marathon include:
 
 1. Determine the list of physical devices (disks and interfaces) for the agent/slave nodes
-2. If running PX-Enterprise in '**air-gapped**' mode, then follow instructions for [running a standalone etcd](/run-air-gap.html#run-a-local-version-of-etcd) and note the IPaddress and Port. 
+2. If running PX-Enterprise in '**air-gapped**' mode, then follow instructions for [running a standalone etcd](/run-etcd.html) and note the IPaddress and Port. 
 3. If running PX-Enterprise, obtain your Lighthouse token.
 
 The following is a sample JSON file that can be used to launch Portworx through Marathon


### PR DESCRIPTION
On the [run-with-mesosphere](http://docs.portworx.com/run-with-mesosphere.html) page, the link for [running a standalone etcd](http://docs.portworx.com/run-air-gap.html#run-a-local-version-of-etcd) is 404ing

I'm assuming it should point to [run-etcd](http://docs.portworx.com/run-etcd.html) instead?