### PR TITLE
add Google Analytics tracking code with proper Tracking ID

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -2,5 +2,15 @@
 
 {% if site.google_analytics %}
 
-<script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create','{{site.google_analytics}}','auto');ga('require','displayfeatures');ga('send','pageview');</script>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-64247527-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
 {% endif %}


### PR DESCRIPTION
Google Analytics is not tracking our docs pages. I looked into is and it looks like it is because _includes/google_analytics defines the Tracking ID as a variable, but the variable is not includes in _config.yml.

I went ahead and hard coded _includes/google_analytics with the Tracking ID.  

Let me know if you prefer I add to _config.yml.

Cheers,

Michael