### PR TITLE
Preparations for AMP

### DIFF
--- a/Lighthouse-Manage-Clusters.md
+++ b/Lighthouse-Manage-Clusters.md
@@ -12,4 +12,4 @@ You can setup alerting preferences for your cluster as the following.
 * On this page you can enable email alerts, and make selections for critical alerts, warning alerts etc. It can also be integrated with syslog server
 * Click Save
 
-![LH-ALERTING-PREFERENCES](images/Cluster-Alerting-Preferences.png "LH Alerting Preferences")
+![LH-ALERTING-PREFERENCES](images/Cluster-Alerting-Preferences.png "LH Alerting Preferences"){:width="795px" height="666px"}

--- a/cli-reference.md
+++ b/cli-reference.md
@@ -990,7 +990,7 @@ USAGE:
 ```
    
 #### pxctl service diags
-When there is an operational failure, you can use pxctl service diags <name-of-px-container> to generate a complete diagnostics package. This package will be automatically uploaded to Portworx. Additionally, the service package can be mailed to Portworx at support@portworx.com. The package will be available at /tmp/diags.tgz inside the PX container. You can use docker cp to extract the diagnostics package.
+When there is an operational failure, you can use pxctl service diags &lt;name-of-px-container&gt; to generate a complete diagnostics package. This package will be automatically uploaded to Portworx. Additionally, the service package can be mailed to Portworx at support@portworx.com. The package will be available at /tmp/diags.tgz inside the PX container. You can use docker cp to extract the diagnostics package.
 ```
 sudo /opt/pwx/bin/pxctl service diags --help
 NAME:
@@ -1199,7 +1199,7 @@ ID                      NAME            SIZE    HA      SHARED  ENCRYPTED       
 ```
 Note: The volume resides on 2 different nodes than the one where it was attached in the above example. Hence the warning.
 
-For an encrypted volume, if you are not using the cluster secret pass in '--secret_key <key>'. Otherwise the cluster secret key will be used.
+For an encrypted volume, if you are not using the cluster secret pass in '--secret_key &lt;key&gt;'. Otherwise the cluster secret key will be used.
 ```
 sudo /opt/pwx/bin/pxctl host attach cliencr
 Volume successfully attached at: /dev/mapper/pxd-enc1013237432577873530

--- a/cos.md
+++ b/cos.md
@@ -27,10 +27,10 @@ Here is an example output from [fio](https://github.com/axboe/fio) when measurin
 The graph below shows the sequential and random read and write performance on high and low CoS volume types:
 
 ### Random Read and Writes
-![CoS Random](images/cos-random.png)
+![CoS Random](images/cos-random.png){:height="2230px" width="726px"}
 
 ### Sequential Read and Writes
-![CoS Sequential](images/cos-seq.png)
+![CoS Sequential](images/cos-seq.png){:height="1204px" width="376px"}
 
 ## Try it out on Amazon
 
@@ -41,7 +41,7 @@ Here, we create volumes of 3 different volume types in AWS.  Refer to [AWS EBS v
 * Create one 100GB standard volume
 * Create one 1000GB IO optimized volume
 
-![EBS Volumes](images/cos.png)
+![EBS Volumes](images/cos.png){:height="1004px" width="246px"}
 
 Here is what you should see when you list your block devices:
 

--- a/cos.md
+++ b/cos.md
@@ -27,10 +27,10 @@ Here is an example output from [fio](https://github.com/axboe/fio) when measurin
 The graph below shows the sequential and random read and write performance on high and low CoS volume types:
 
 ### Random Read and Writes
-![CoS Random](images/cos-random.png){:height="2230px" width="726px"}
+![CoS Random](images/cos-random.png){:width="2230px" height="726px"}
 
 ### Sequential Read and Writes
-![CoS Sequential](images/cos-seq.png){:height="1204px" width="376px"}
+![CoS Sequential](images/cos-seq.png){:width="1204px" height="376px"}
 
 ## Try it out on Amazon
 
@@ -41,7 +41,7 @@ Here, we create volumes of 3 different volume types in AWS.  Refer to [AWS EBS v
 * Create one 100GB standard volume
 * Create one 1000GB IO optimized volume
 
-![EBS Volumes](images/cos.png){:height="1004px" width="246px"}
+![EBS Volumes](images/cos.png){:width="1004px" height="246px"}
 
 Here is what you should see when you list your block devices:
 

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1160,3 +1160,10 @@ h4.panel-title {
     padding-top: 0px;
     margin-top: 0px;
 }
+
+.topfork {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border: 0;
+}

--- a/deploy_px_with_rancher.md
+++ b/deploy_px_with_rancher.md
@@ -18,7 +18,7 @@ For availability zone, use either "West N. California", or "East N. Virginia".  
 * For US-East (N. Virginia), use **ami-d0651bc7** as the AMI image name.
 * Specify **128GB** as the root size
 
-![Configuring Instance](images/rancherpx.png "Depoloying Portworx with Rancher")
+![Configuring Instance](images/rancherpx.png "Depoloying Portworx with Rancher"){:height="2426px" width="904px"}
 
 ### Step 3 : Advanced Options
 

--- a/deploy_px_with_rancher.md
+++ b/deploy_px_with_rancher.md
@@ -18,7 +18,7 @@ For availability zone, use either "West N. California", or "East N. Virginia".  
 * For US-East (N. Virginia), use **ami-d0651bc7** as the AMI image name.
 * Specify **128GB** as the root size
 
-![Configuring Instance](images/rancherpx.png "Depoloying Portworx with Rancher"){:height="2426px" width="904px"}
+![Configuring Instance](images/rancherpx.png "Depoloying Portworx with Rancher"){:width="2426px" height="904px"}
 
 ### Step 3 : Advanced Options
 

--- a/get-started-asap.md
+++ b/get-started-asap.md
@@ -19,7 +19,7 @@ This template includes the following to enable Portworx deployments:
 ### Configure and Launch the Portworx stack
 
 
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/Portworx_CoreOS_Stack_v1.2_Feb06_2017" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/Portworx_CoreOS_Stack_v1.2_Feb06_2017" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px" class="cf-stack"></a></p>
 
 - Click the "Launch Stack" button above.  The Portworx Template is automatically loaded into CloudFormation.   Click **Next**
 

--- a/get-started-asap.md
+++ b/get-started-asap.md
@@ -19,7 +19,7 @@ This template includes the following to enable Portworx deployments:
 ### Configure and Launch the Portworx stack
 
 
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/Portworx_CoreOS_Stack_v1.2_Feb06_2017" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/Portworx_CoreOS_Stack_v1.2_Feb06_2017" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
 
 - Click the "Launch Stack" button above.  The Portworx Template is automatically loaded into CloudFormation.   Click **Next**
 

--- a/index.md
+++ b/index.md
@@ -17,13 +17,13 @@ Portworx provides scale-out storage for containers. Portworx storage is delivere
 * Is radically simple.
 
 **Try It Now!**
-[![](/images/launch.png){:height="64px" width="64px"}](/get-started-asap.html)
+[![](/images/launch.png){:height="64px" width="64px" .launch-icon}](/get-started-asap.html)
 
 Portworx technology is available as PX-Developer and PX-Enterprise.
 
 ## Join us on Slack!
 
-[![](/images/slack.png){:height="48px" width="48px"}](http://slack.portworx.com)
+[![](/images/slack.png){:height="48px" width="48px" .slack-icon}](http://slack.portworx.com)
 
 ## PX-Developer
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ keywords: portworx, px-enterprise, px-developer, containers, storage
 sidebar: home_sidebar
 ---
 
-<a href="https://github.com/portworx/px-docs"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/portworx/px-docs"><img class="topfork" width="149px" height="149px" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 
 Portworx provides scale-out storage for containers. Portworx storage is delivered as a container that is installed on your servers. Portworx technology:
 
@@ -17,13 +17,13 @@ Portworx provides scale-out storage for containers. Portworx storage is delivere
 * Is radically simple.
 
 **Try It Now!**
-[![](/images/launch.png)](/get-started-asap.html)
+[![](/images/launch.png){:height="64px" width="64px"}](/get-started-asap.html)
 
 Portworx technology is available as PX-Developer and PX-Enterprise.
 
 ## Join us on Slack!
 
-[![](/images/slack.png)](http://slack.portworx.com)
+[![](/images/slack.png){:height="48px" width="48px"}](http://slack.portworx.com)
 
 ## PX-Developer
 
@@ -38,9 +38,7 @@ PX-Developer features:
 * Support for up three servers per cluster and 1 TB per volume
 * Requires an etcd or Consul key/value store
 
-<FORM METHOD="LINK" ACTION="get-started-px-developer.html">
-<INPUT TYPE="submit" VALUE="Get Started with PX-Developer">
-</FORM>
+<a href="get-started-px-developer.html" class="btn btn-primary">Get Started with PX-Developer</a>
 <br/>
 
 ## PX-Enterprise
@@ -60,9 +58,7 @@ PX-Enterprise is for DevOps and IT ops teams managing storage for containerized 
 * Command-line interface
 * RESTful API for automation and statistics
 
-<FORM METHOD="LINK" ACTION="get-started-px-enterprise.html">
-<INPUT TYPE="submit" VALUE="Get Started with PX-Enterprise">
-</FORM>
+<a href="get-started-px-enterprise.html" class="btn btn-primary">Get Started with PX-Enterprise</a>
 
 
 [Contact us](http://portworx.com/contact-us/) to share feedback, work with us, and to request features.

--- a/jenkins.md
+++ b/jenkins.md
@@ -25,7 +25,7 @@ docker run -d -p 49001:8080 -v jenkins_vol1:/var/jenkins_home:z -t jenkins
 Bring up a browser to the host where you launched Jenkins on port 49001.
 You should see 
 
-![jenkins1](images/jenkins1.png)
+![jenkins1](images/jenkins1.png){:height="1998px" width="1170px"}
 
 Run "docker ps" to find the CONTAINER ID of the Jenkins container:
 
@@ -45,12 +45,12 @@ docker exec -it 9dfa72c4328c cat /var/jenkins_home/secrets/initialAdminPassword
 
 Install the Suggested Plugins
 
-![Install Suggested Plugins](images/jenkins2.png)
+![Install Suggested Plugins](images/jenkins2.png){:height="1998px" width="1184px"}
 
 Configure the Admin User
 
-![Configure Admin User](images/jenkins3.png)
+![Configure Admin User](images/jenkins3.png){:height="1992px" width="1156px"}
 
 Start Using Jenkins
 
-![Start Using Jenkins](images/jenkins4.png)
+![Start Using Jenkins](images/jenkins4.png){:height="2560px" width="1258px"}

--- a/jenkins.md
+++ b/jenkins.md
@@ -25,7 +25,7 @@ docker run -d -p 49001:8080 -v jenkins_vol1:/var/jenkins_home:z -t jenkins
 Bring up a browser to the host where you launched Jenkins on port 49001.
 You should see 
 
-![jenkins1](images/jenkins1.png){:height="1998px" width="1170px"}
+![jenkins1](images/jenkins1.png){:width="1998px" height="1170px"}
 
 Run "docker ps" to find the CONTAINER ID of the Jenkins container:
 
@@ -45,12 +45,12 @@ docker exec -it 9dfa72c4328c cat /var/jenkins_home/secrets/initialAdminPassword
 
 Install the Suggested Plugins
 
-![Install Suggested Plugins](images/jenkins2.png){:height="1998px" width="1184px"}
+![Install Suggested Plugins](images/jenkins2.png){:width="1998px" height="1184px"}
 
 Configure the Admin User
 
-![Configure Admin User](images/jenkins3.png){:height="1992px" width="1156px"}
+![Configure Admin User](images/jenkins3.png){:width="1992px" height="1156px"}
 
 Start Using Jenkins
 
-![Start Using Jenkins](images/jenkins4.png){:height="2560px" width="1258px"}
+![Start Using Jenkins](images/jenkins4.png){:width="2560px" height="1258px"}

--- a/launch-via-lighthouse.md
+++ b/launch-via-lighthouse.md
@@ -12,35 +12,35 @@ This section walks through installing and configuring a PX-Enterprise cluster vi
 
 Log in to the PX-Enterprise Lighthouse console. If a cluster has not already been created for your account, click the **Manage Clusters** menu and then click **Manage Clusters**.
 
-![Manage Clusters menu](images/clusters-manage-clusters-menu-updated-2.png "Manage Clusters menu")
+![Manage Clusters menu](images/clusters-manage-clusters-menu-updated-2.png "Manage Clusters menu"){:width="312px" height="228px"}
 
 On the **Clusters** page, click the **+** icon to create a new storage cluster.
 
-![Add a cluster](images/clusters-add-updated.png "Add a cluster")
+![Add a cluster](images/clusters-add-updated.png "Add a cluster"){:width="1115px" height="510px"}
 
 Then, type a unique Name for your PX-Enterprise cluster and click **Create**.
 
-![Name a new cluster](images/clusters-new-updated.png "Name a new cluster")
+![Name a new cluster](images/clusters-new-updated.png "Name a new cluster"){:width="848px" height="406px"}
 
 (Don't use the "Existing Cluster" option, unless directed by Portworx Support.)
 
 The new cluster appears in the Clusters list.
 
-![List of clusters](images/clusters-list-updated-2.png "List of clusters")
+![List of clusters](images/clusters-list-updated-2.png "List of clusters"){:width="1590px" height="503px"}
 
 ## Step 2: Run discovery and bootstrap on a server node
 
 You will now add your first server node to the storage cluster. On the **Clusters** page, click **Get Startup Script** for the cluster you just created.
 
-![Startup script example](images/clusters-list-updated-2.png "Startup script example")
+![Startup script example](images/clusters-list-updated-2.png "Startup script example"){:width="1590px" height="503px"}
 
 A window containing a `curl` command opens. The following `curl` example includes an authentication token and downloads the PX-Enterprise Docker container.
 
-![Startup script to add a cluster](images/startup-script-window-updated.png "Startup script to add a cluster")
+![Startup script to add a cluster](images/startup-script-window-updated.png "Startup script to add a cluster"){:width="794px" height="812px"}
 
 Log in to each node that will install PX-Enterprise and join the cluster. Open a terminal window and run as `root` or `sudo su` to give privileges. On your system, copy the `curl` string provided by the pop-up window and paste it into a terminal session and press Enter, as shown below.
 
-![Startup script status messages](images/startup-script-result-updated.png "Startup script status messages")
+![Startup script status messages](images/startup-script-result-updated.png "Startup script status messages"){:width="854px" height="492px"}
 
 ## Step 3: Configure the Hardware Profile
 
@@ -48,29 +48,29 @@ The bootstrap startup script discovers the server/node configuration. It lets yo
 
 First menu is ***Storage Selection Menu*** You can either pick individual storage devices or can choose to add all devices.
 
-![Hardware configuration](images/storage-selection-menu.png "Hardware configuration")
+![Hardware configuration](images/storage-selection-menu.png "Hardware configuration"){:width="724px" height="405px"}
 
 Second menu is ***Data Network Interface Selection Menu*** This will let you assign one of your network interfaces as data interface for your this node.
 The *data interface* is used between server nodes, primarily for data transfer as part of data availability (that is, multi-node data replication).
 
-![Hardware configuration](images/data-network-interface-selection-menu.png "Hardware configuration")
+![Hardware configuration](images/data-network-interface-selection-menu.png "Hardware configuration"){:width="728px" height="410px"}
 
 Last menu is ***Management Network Interface Selection Menu*** This will let you assign one of your network interfaces as management interface for your this PX node.
 The *management interface* is used for communication between the hosted PX-Enterprise product and the individual server nodes, for control-path as well as statistics and metrics.
 
 Note: You can choose to use the same interface both for data interface and management interface.PX-Enterprise requires at least one NIC and only needs a maximum of two NICs.
 
-![Hardware configuration](images/management-network-interface-selection-menu.png "Hardware configuration")
+![Hardware configuration](images/management-network-interface-selection-menu.png "Hardware configuration"){:width="725px" height="409px"}
 
 To instruct the PX-Enterprise container on the server node to complete the installation, click **Commit Selections** on the Management Network Interface Selection Menu. Upon installation, PX-Enterprise aggregates the specified storage and uses the network interfaces selected.
 
 From the server node that ran the `curl` command, you should see the following status:
 
-![Status messages after activation](images/status-messages-after-activate.png "Status messages after activation")
+![Status messages after activation](images/status-messages-after-activate.png "Status messages after activation"){:width="1379px" height="736px"}
 
 Bootstrap script also saves your selection as a unique *Hardware Profile*. You can reference this on any other node where you want to run PX-Enterprise with the same storage and network elements.
 
-![Hardware configuration](images/hardware-profile-example.png "Hardware configuration")
+![Hardware configuration](images/hardware-profile-example.png "Hardware configuration"){:width="1379px" height="118px"}
 
 ## Step 4: Expand the cluster
 
@@ -80,4 +80,4 @@ You can add new servers nodes to the existing cluster by running the bootstrap s
 
 At this point you will have a PX-Enterprise cluster that you will be able to monitor from PX-Enterprise console.
 
-![New cluster in Lighthouse](images/new-cluster-in-lighthouse.png "New cluster in Lighthouse")
+![New cluster in Lighthouse](images/new-cluster-in-lighthouse.png "New cluster in Lighthouse"){:width="1394px" height="595px"}

--- a/manage-users-groups.md
+++ b/manage-users-groups.md
@@ -6,13 +6,13 @@ sidebar: home_sidebar
 ---
 To create users, click the gear icon in the upper-right corner of the console and choose **Manage Users**.
 
-![User Admin selected in Settings menu](images/settings-user-admin-updated.png "User Admin selected in Settings menu")
+![User Admin selected in Settings menu](images/settings-user-admin-updated.png "User Admin selected in Settings menu"){:width="278px" height="328px"}
 
 Click the **New User** button. 
 
-![New User dialog box](images/settings-new-user-updated.png "New User dialog box")
+![New User dialog box](images/settings-new-user-updated.png "New User dialog box"){:width="1157px" height="399px"}
 
 Fill in the user details, and click **Save**. Giving a user Admin permissions provides the user greater visibility across all clusters as well as the ability to create additional users.
 
-![New User dialog box](images/settings-new-user-creation.png "New User dialog box")
+![New User dialog box](images/settings-new-user-creation.png "New User dialog box"){:width="595px" height="305px"}
 

--- a/overview.md
+++ b/overview.md
@@ -12,7 +12,7 @@ Each server has the Portworx container and the Docker daemon.
 Servers join a cluster and share configuration through PX-Enterprise or the key/value store, such as etcd.
 The Portworx container pools the capacity of the storage media residing on the server. You easily select storage media through the [config.json](https://raw.githubusercontent.com/portworx/px-dev/master/conf/config.json) file.
 
-![Portworx cluster architecture](images/cluster-architecture.png "Portworx cluster architecture")
+![Portworx cluster architecture](images/cluster-architecture.png "Portworx cluster architecture"){:width="442px" height="492px"}
 
 Storage volumes are thinly provisioned, using capacity only as an application consumes it. Volumes are replicated across the nodes within the cluster, per a volume’s configuration, to ensure high availability.
 
@@ -22,7 +22,7 @@ Using MySQL as an example, a Portworx storage cluster has the following characte
 * This data gets stored in the container’s volume, managed by Portworx.
 * Portworx synchronously and automatically replicates writes to the volume across the cluster.
 
-![Portworx cluster architecture with MySQL](images/cluster-architecture-example-mysql.png "Portworx cluster architecture with MySQL")
+![Portworx cluster architecture with MySQL](images/cluster-architecture-example-mysql.png "Portworx cluster architecture with MySQL"){:width="839px" height="276px"}
 
 Each volume specifies its request of resources (such as its max capacity and IOPS) and its individual requirements (such as ext4 as the file system and block size).
 

--- a/performance.md
+++ b/performance.md
@@ -40,14 +40,14 @@ from PCSD - Product Collaboration Systems Division
   * PX-Enterprise v1.0.8
 
 ### Random read performance overhead
-![Perf Read](images/perf-read.png)
+![Perf Read](images/perf-read.png){:width="655px" height="199px"}
 
 ### Random write performance overhead
-![Perf Write](images/perf-write.png)
+![Perf Write](images/perf-write.png){:width="633px" height="186px"}
 
 ### mysql performance overhead
 In this example, we measure the performance as measured by running a `mysql` workload against the baremetal server and then against a PX volume on that same server.
-![Perf mysql](images/perf-mysql.png)
+![Perf mysql](images/perf-mysql.png){:width="664px" height="199px"}
 
 ## Containerized NoSQL Workloads: Cassandra performance gains with running PX-Enterprise
 
@@ -62,21 +62,21 @@ The Read OPS/sec and Write OPS/sec improvements graphs show how running with PX-
 
 ### Cassandra with PX-Enterprise - Read OPS/sec improvements
 
-![Cassandra Reads Ops](images/Cassandra-PX Read OPS.png)
+![Cassandra Reads Ops](images/Cassandra-PX Read OPS.png){:width="1056px" height="648px"}
 
 ### Cassandra with PX-Enterprise - Write OPS/sec improvements
 
-![Cassandra Writes Ops](images/Cassandra-PX Write Ops.png)
+![Cassandra Writes Ops](images/Cassandra-PX Write Ops.png){:width="1056px" height="648px"}
 
 The latency graphs below demonstrate the network-optimized replication performance of PX-Enterprise as it accelerates cassandra performance by delivering IO at very low latencies to the Cassandra Container
 
 ### Cassandra with PX-Enterprise - Read Latency improvements
 
-![Cassandra Read Lats](images/Cassandra-PX Read Latencies.png)
+![Cassandra Read Lats](images/Cassandra-PX Read Latencies.png){:width="1066px" height="650px"}
 
 ### Cassandra with PX-Enterprise - Write Latency improvements
 
-![Cassandra Write Lats](images/Cassandra-PX Write latencies.png)
+![Cassandra Write Lats](images/Cassandra-PX Write latencies.png){:width="1054px" height="696px"}
 
 
 

--- a/portworx-on-aws-cloudformation.md
+++ b/portworx-on-aws-cloudformation.md
@@ -18,7 +18,7 @@ This template is based on the CoreOS "Stable" Channel (version 1235.4.0) and inc
 
 ### Step 1: Configure and Launch the Portworx stack
 
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/2017019oeI-Portworx_CoreOS_Stack_v36ky4q0o5aniv7nslr74f7mbo6r" rel="nofollow noreferrer"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/2017019oeI-Portworx_CoreOS_Stack_v36ky4q0o5aniv7nslr74f7mbo6r" rel="nofollow noreferrer"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
 
 - Click the "Launch Stack" button above.  The Portworx Template is automatically loaded into CloudFormation.   Click **Next**
 

--- a/portworx-on-aws-cloudformation.md
+++ b/portworx-on-aws-cloudformation.md
@@ -18,7 +18,7 @@ This template is based on the CoreOS "Stable" Channel (version 1235.4.0) and inc
 
 ### Step 1: Configure and Launch the Portworx stack
 
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/2017019oeI-Portworx_CoreOS_Stack_v36ky4q0o5aniv7nslr74f7mbo6r" rel="nofollow noreferrer"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-STACK&amp;templateURL=https://s3.amazonaws.com/cf-templates-1oefrvxk1p71o-us-east-1/2017019oeI-Portworx_CoreOS_Stack_v36ky4q0o5aniv7nslr74f7mbo6r" rel="nofollow noreferrer"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px" class="cf-stack"></a></p>
 
 - Click the "Launch Stack" button above.  The Portworx Template is automatically loaded into CloudFormation.   Click **Next**
 

--- a/portworx-on-azure.md
+++ b/portworx-on-azure.md
@@ -19,7 +19,7 @@ Follow the instuctions from Azure documentation [How to attach a data disk to a 
 Your deployment will look something like following:
 
 
-![Azure Add Disk](images/azure-add-disk.png "Add Disk")
+![Azure Add Disk](images/azure-add-disk.png "Add Disk"){:width="1483px" height="477px"}
 
 ### Step 3: Install Docker for the appropriate OS Version 
 Portworx recommends Docker 1.12 with [Device Mapper](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/#/configure-docker-with-devicemapper).
@@ -36,10 +36,10 @@ Alternatively, you can either run the 'px_bootstrap' script from curl, or constr
 
 From the server node running px-enterprise container, you should see the following status:
 
-![PX-Cluster on Azure](images/azure-pxctl-status.png "PX-Cluster on Azure")
+![PX-Cluster on Azure](images/azure-pxctl-status.png "PX-Cluster on Azure"){:width="807px" height="443px"}
 
 
 You should also be able to monitor cluster from PX-Enterprise console:
 
-![Azure-Cluster on Lighthouse](images/azure-cluster-on-lighthouse-updated.png "Azure-Cluster on Lighthouse")
+![Azure-Cluster on Lighthouse](images/azure-cluster-on-lighthouse-updated.png "Azure-Cluster on Lighthouse"){:width="1404px" height="601px"}
 

--- a/portworx-on-ddc.md
+++ b/portworx-on-ddc.md
@@ -113,6 +113,6 @@ docker  run -d -P -e constraint:pxfabric==px-cluster1 --name db mysql
 
 
 Or, from the UCP GUI for launching a container, specify a constraint for `pxfabric` as follows:
-![UCP GUI constraints](images/constraints.png)
+![UCP GUI constraints](images/constraints.png){:width="791px" height="148px"}
 
 For more information on Docker Filters and Constraints, see [Swarm filters](https://docs.docker.com/swarm/scheduler/filter/).

--- a/portworx-on-ecs.md
+++ b/portworx-on-ecs.md
@@ -19,14 +19,14 @@ Note that Portworx recommends a minimum cluster size of 3 nodes.
 #### Create the cluster in the console
 Log into the ECS console and create an ecs cluster called "ecs-demo".
 
-![ecs-clust-create](images/ecs-clust-create.png "ecs").
+![ecs-clust-create](images/ecs-clust-create.png "ecs"){:width="1162px" height="457px"}.
 
 We will use the name `ecs-demo` to configure your EC2 instances and the `ecs-cli`.
 
 #### Create your EC2 instances
 Your EC2 instances must have the correct IAM role set.  Follow these [IAM instructions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html).
 
-![IAM](images/iam-role.png "IAM")
+![IAM](images/iam-role.png "IAM"){:width="935px" height="592px"}
 
 #### Add storage capacity to each instance
 You will need to provision storage to these instances by creating new EBS volumes and attaching it to the instances.  Portworx will be using these volumes to provision storage to your containers.
@@ -130,7 +130,7 @@ redis:
 
 You can view the task in the ECS console.
 
-![task](images/ecs-task.png "task")
+![task](images/ecs-task.png "task"){:width="1512px" height="763px"}
 
 #### Creating a task via the console
 
@@ -144,11 +144,11 @@ Create a new docker volume like we did in step 4.
 
 Go to AWS ECS console, On the same cluster "ecs-demo"; create a new task definition.
 
-![task](images/aws-ecs-image00.PNG)
+![task](images/aws-ecs-image00.PNG){:width="1164px" height="845px"}
 
 On the new task definition screen; first add a volume for your container.  Both the name and the source path must be the name of the Portworx volume.
-![task](images/aws-ecs-image02.PNG)
+![task](images/aws-ecs-image02.PNG){:width="1135px" height="631px"}
 
 Then add a new container - In the new container configuration page, go to the advanced container configuration.  Under the section of Storage and Logging, define your mount points and the volume path.  Click the drop down selection next to "Mount Points" and choose volume-0. Then enter the path for that mount points, for example `/data`.
 
-![task](images/aws-ecs-image03.PNG)
+![task](images/aws-ecs-image03.PNG){:width="738px" height="372px"}

--- a/portworx-on-ecs2.md
+++ b/portworx-on-ecs2.md
@@ -17,7 +17,7 @@ Note that Portworx recommends a minimum cluster size of 3 nodes.
 #### Create the cluster in the console
 Log into the ECS console and create an ecs cluster called "ecs-demo1".
 
-![ecs-clust-create](images/aws-ecs-setup_withPX_001y.PNG "ecs-1").
+![ecs-clust-create](images/aws-ecs-setup_withPX_001y.PNG "ecs-1"){:width="1023px" height="928px"}.
 
 
 On above, the Container Instance IAM role is used by the ECS container agent. These ECS container agent is deployed by default with the EC2 instances from the ECS wizard. And these agent makes call to AWS ECS API actions on your behalf, thus these EC2 instances that running the ECS container agent require an IAM role that has permission to join ECS cluster and launch containers within the cluster. 
@@ -53,15 +53,15 @@ Your EC2 instances must have the correct IAM role set.  Follow these [IAM instru
 
 After the ECS cluster "ecs-demo1" successfully launched, the corresponding EC2 instances that belong to this ECS cluster can be found under the "ECS instance" tab of ECS console or from AWS EC2 console. Each of this EC2 instance is running with an amazon-ecs-agent in docker container. 
 
-![ecs-clust-create](images/aws-ecs-setup_withPX_003xx.PNG "ecs-3").
+![ecs-clust-create](images/aws-ecs-setup_withPX_003xx.PNG "ecs-3"){:width="1723px" height="863px"}.
 
 
 #### Add storage capacity to each EC2 instance
 Provisioning storage to these EC2 instances by creating new EBS volumes and attaching them to these EC2 instances.  Portworx will be using these EBS volumes to provision storage to your containers. Below we are creating a 20GB EBS volume on the same region "us-east-1b" of the launched EC2 instances. Ensure all ECS instances are attached with the EBS volumes.
 
-![ecs-clust-create](images/aws-ecs-setup_withPX_002y.PNG "ecs-2" ).
+![ecs-clust-create](images/aws-ecs-setup_withPX_002y.PNG "ecs-2" ){:width="1831px" height="580px"}.
 
-![ecs-clust-create](images/aws-ecs-setup_withPX_004yy.PNG "ecs-4").
+![ecs-clust-create](images/aws-ecs-setup_withPX_004yy.PNG "ecs-4"){:width="1477px" height="699px"}.
 
 
 ### Step 2: Deploy Portworx
@@ -153,9 +153,9 @@ From your linux workstation download and setup AWS ECS CLI utilities
          59701c44-c267-4c85-a8c0-ff87910af535/web           RUNNING                                                                 ecscompose-root:1
   5. You can also view the task status in the ECS console.
 
-![task](images/aws-ecs-setup_withPX_003t.PNG "ecs3t")
+![task](images/aws-ecs-setup_withPX_003t.PNG "ecs3t"){:width="1290px" height="509px"}
   6. On the above ECS console, Clusters -> pick your cluster ```ecs-demo1``` and click on the ```Container Instance``` ID that corresponding to the running task. This will display the containers information including where are these containers deployed into which EC2 instance. Below, we find that the task defined containers are deployed on EC2 instance with public IP address ```52.91.191.220```.
-![task](images/aws-ecs-setup_withPX_003z.PNG "ecs3z")
+![task](images/aws-ecs-setup_withPX_003z.PNG "ecs3z"){:width="1136px" height="598px"}
   7. From above, ssh into the EC2 instance 52.91.191.220 and verify PX volume is attached to running container.
          
          [ec2-user@ip-172-31-31-61 ~]$ sudo docker ps -a
@@ -191,25 +191,24 @@ Create a ECS tasks definition directly via the ECS console (GUI) and using PX vo
 
   2. In AWS ECS console, choose the previously created cluster ```ecs-demo1```; then create a new task definition.
  
-   ![task](images/aws-ecs-setup_withPX_005y.PNG)
+   ![task](images/aws-ecs-setup_withPX_005y.PNG){:width="1345px" height="594px"}
   3. From the new task definition screen, enter the task definition name ```redis-demo``` and click ```Add volume``` near the bottom of the page.
-  ![task](images/aws-ecs-setup_withPX_005yy.PNG)
+  ![task](images/aws-ecs-setup_withPX_005yy.PNG){:width="1404px" height="777px"}
   4. Enter the ```Name``` in the Add volume screen, that is just the name for your volume defined in this task definition and no need to be the same as the PX volume name. Then enter the ```Source path```, and this is the PX volume name ```demovol```.
-  ![task](images/aws-ecs-setup_withPX_005yyx.PNG)
+  ![task](images/aws-ecs-setup_withPX_005yyx.PNG){:width="1531px" height="485px"}
   5. After added the volume, click ```Add container``` button to define your containers specification.
-  ![task](images/aws-ecs-setup_withPX_006y.PNG)
+  ![task](images/aws-ecs-setup_withPX_006y.PNG){:width="1520px" height="844px"}
   6. From the ```Add container ``` screen, enter the ```Container name``` "redis"  and ```Image*``` "redis" ; then click the ```Add``` button.
-  ![task](images/aws-ecs-setup_withPX_006z.PNG)
+  ![task](images/aws-ecs-setup_withPX_006z.PNG){:width="1111px" height="603px"}
   7. Adding another container, on the same  Create a Task Definition screen, click ```Add container``` button. On the Add container screen, enter the ```Container name``` "web" and ```Image*``` ["binocarlos/moby-counter"](https://hub.docker.com/r/binocarlos/moby-counter/) and On ```NETWORK SETTINGS``` ```Links``` enter "redis:redis" ; then on ```STORAEE AND LOGGING``` ```Mount Points``` select from drop down "volume0" and enter the ```Container path``` "/data" ; and then click ```Add``` button.
-  ![task](images/aws-ecs-setup_withPX_007y.PNG)
+  ![task](images/aws-ecs-setup_withPX_007y.PNG){:width="1422px" height="953px"}
   8. On the same task definition screen, click ```create``` button at the of the screen.
-  ![task](images/aws-ecs-setup_withPX_008y.PNG)
+  ![task](images/aws-ecs-setup_withPX_008y.PNG){:width="1480px" height="816px"}
   9. From the AWS ECS console, Task Definitions, select the definition "redis-demo" and click ```Actions``` and select ```run```
-  ![task](images/aws-ecs-setup_withPX_009y.PNG)
+  ![task](images/aws-ecs-setup_withPX_009y.PNG){:width="1510px" height="404px"}
   10. Click ```Run Task```
-  ![task](images/aws-ecs-setup_withPX_010y.PNG)
+  ![task](images/aws-ecs-setup_withPX_010y.PNG){:width="1304px" height="713px"}
   11. You will see the task is submitted and change status from ```PENDING``` to ```RUNNING```.
-  ![task](images/aws-ecs-setup_withPX_011y.PNG)
-  ![task](images/aws-ecs-setup_withPX_012y.PNG)
-  
+  ![task](images/aws-ecs-setup_withPX_011y.PNG){:width="1157px" height="598px"}
+  ![task](images/aws-ecs-setup_withPX_012y.PNG){:width="1570px" height="640px"}  
   

--- a/portworx-on-packet.md
+++ b/portworx-on-packet.md
@@ -32,7 +32,7 @@ Follow the instuctions on Packet's knowledge base for [installing and attaching 
 Your deployment will look something like following:
 
 
-![Attach Block Storage Volume](images/block-storage-on-packet.png "Attach Block Storage Volume")
+![Attach Block Storage Volume](images/block-storage-on-packet.png "Attach Block Storage Volume"){:width="1878px" height="416px"}
 
 ### Step 4: Install and Run the Packet host utilities for block storage 
 On each host, download and install the [Packet block-storage utilities](https://github.com/packethost/packet-block-storage)
@@ -63,9 +63,9 @@ Use the docker run command to launch PX-Enterprise, substituting the appropriate
 Alternatively, you can either run the 'px_bootstrap' script from curl, or construct your own [config.json](config-json.html) file.
 
 From the server node running px-enterprise container, you should see the following status:
-![PX-Cluster on Packet](images/px-cluster-on-packet.png "PX-Cluster on Packet")
+![PX-Cluster on Packet](images/px-cluster-on-packet.png "PX-Cluster on Packet"){:width="816px" height="458px"}
 
 
 You should also be able to monitor cluster from PX-Enterprise console:
-![Packet-Cluster on Lighthouse](images/packet-cluster-on-lighthouse.png "Packet-Cluster on Lighthouse")
+![Packet-Cluster on Lighthouse](images/packet-cluster-on-lighthouse.png "Packet-Cluster on Lighthouse"){:width="1709px" height="703px"}
 

--- a/portworx-on-rackspace.md
+++ b/portworx-on-rackspace.md
@@ -21,7 +21,7 @@ Follow the instuctions from Rackspace documentation [Create and attach a Cloud B
 
 Your deployment will look something like the following:
 
-![Rackspace Add Block Storage Volumes](images/rackspace-add-disk.png "Add Block Storage") 
+![Rackspace Add Block Storage Volumes](images/rackspace-add-disk.png "Add Block Storage"){:width="1632px" height="1172px"} 
 
 
 Note: Volume cannot not be attached until the server is available
@@ -45,12 +45,12 @@ Alternatively, you can either run the 'px_bootstrap' script from curl, or constr
 
 From the server node running px-enterprise container, you should see the following status:
 
-![PX-Cluster on Rackspace](images/rackspace-pxctl-status.png "PX-Cluster on Azure")
+![PX-Cluster on Rackspace](images/rackspace-pxctl-status.png "PX-Cluster on Azure"){:width="1560px" height="586px"}
 
 
 You should also be able to monitor cluster from PX-Enterprise console:
 
-![Rackspace-Cluster on Lighthouse](images/rackspace-cluster-on-lighthouse-updated.png "Rackspace-Cluster on Lighthouse")
+![Rackspace-Cluster on Lighthouse](images/rackspace-cluster-on-lighthouse-updated.png "Rackspace-Cluster on Lighthouse"){:width="2552px" height="1180px"}
 
 
 

--- a/portworx-on-softlayer.md
+++ b/portworx-on-softlayer.md
@@ -16,7 +16,7 @@ Portworx recommends a minimum cluster size of 3 nodes.
 
 SoftLayer lets you choose either local disk or SAN disk. If your environment have nodes with both of these, make sure that there is network connectivity between the nodes.
 
-![SoftLayer Add Disk](images/softlayer-add-disk.png "Add Disk")
+![SoftLayer Add Disk](images/softlayer-add-disk.png "Add Disk"){:width="777px" height="637px"}
 
 ### Step 3: Install Docker for the appropriate OS Version 
 Portworx recommends Docker 1.12 with [Device Mapper](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/#/configure-docker-with-devicemapper).
@@ -33,10 +33,10 @@ Alternatively, you can either run the 'px_bootstrap' script from curl, or constr
 
 From the server node running px-enterprise container, you should see the following status:
 
-![PX-Cluster on SoftLayer](images/softlayer-pxctl-status-updated.png "PX-Cluster on SoftLayer")
+![PX-Cluster on SoftLayer](images/softlayer-pxctl-status-updated.png "PX-Cluster on SoftLayer"){:width="854px" height="543px"}
 
 
 You should also be able to monitor cluster from PX-Enterprise console:
 
-![SoftLayer-Cluster on Lighthouse](images/softlayer-cluster-on-lighthouse-updated.png "SoftLayer-Cluster on Lighthouse")
+![SoftLayer-Cluster on Lighthouse](images/softlayer-cluster-on-lighthouse-updated.png "SoftLayer-Cluster on Lighthouse"){:width="1362px" height="586px"}
 

--- a/portworx-with-prometheus.md
+++ b/portworx-with-prometheus.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 ---
 
 PX storage and network stats can easily be integrated with [**prometheus**](https://prometheus.io) or similar applications.
-These stats are exported at port 9001; your application can poll http://<IP_ADDRESS>:9001/metrics to get their runtime values.
+These stats are exported at port 9001; your application can poll http://&lt;IP_ADDRESS&gt;:9001/metrics to get their runtime values.
 
 ## Integration with Prometheus
 

--- a/portworx-with-prometheus.md
+++ b/portworx-with-prometheus.md
@@ -13,7 +13,7 @@ These stats are exported at port 9001; your application can poll http://<IP_ADDR
 ### Step 1: Configuring Prometheus to watch px node
 Add your px node as a target in Prometheus config file:
 
-![Prometheus Config File](images/prometheus-config.png "Prometheus Config File")
+![Prometheus Config File](images/prometheus-config.png "Prometheus Config File"){:width="1702px" height="970px"}
 
 In the example above, our node has IP address of 54.173.138.1, so Prometheus is watching 54.173.138.1:9001 as its target. This can be any node in the PX cluster.
 
@@ -21,17 +21,17 @@ In the example above, our node has IP address of 54.173.138.1, so Prometheus is 
 
 Once Prometheus starts watching px node, you will be able to see new portworx related metrics added to Prometheus. 
 
-![PX Metrics in Prometheus](images/px-metrics-in-prometheus.png "PX Metrics in Prometheus")
+![PX Metrics in Prometheus](images/px-metrics-in-prometheus.png "PX Metrics in Prometheus"){:width="1110px" height="618px"}
 
 You can now build graphs:
 
-![Building a Graph with Prometheus](images/building-a-graph-with-prometheus.png "Building a Graph with Prometheus")
+![Building a Graph with Prometheus](images/building-a-graph-with-prometheus.png "Building a Graph with Prometheus"){:width="2006px" height="1154px"}
 
 **Note**
 
 A curl request on port 9001 also shows the stats:
 
-![Curl Request on 9001](images/curl-request-on-9001.png "Curl Request on 9001")
+![Curl Request on 9001](images/curl-request-on-9001.png "Curl Request on 9001"){:width="1856px" height="1372px"}
 
 ## Storage and Network stats
 

--- a/px-faqs.md
+++ b/px-faqs.md
@@ -78,4 +78,4 @@ Please see the [config-json file definition](/config-json.html ).
 Regardless, all data requests between the container and the PX volume driver will be handled locally on that host.
 
 ## Did we miss your question? 
-If so, please let us know here: <a class="email" title="Submit feedback" href="#" onclick="javascript:window.location='mailto:{{site.feedback_email}}?subject={{site.feedback_subject_line}} feedback&body=I have some feedback about the {{page.title}} page: ' + window.location.href;"><i class="fa fa-envelope-o"></i> Feedback</a>
+If so, please let us know here: <a class="email" title="Submit feedback" href="mailto:{{site.feedback_email}}?subject={{site.feedback_subject_line}} feedback&body=I have some feedback about the {{page.title}} page"><i class="fa fa-envelope-o"></i> Feedback</a>

--- a/run-lighthouse-with-secure-etcd.md
+++ b/run-lighthouse-with-secure-etcd.md
@@ -128,4 +128,4 @@ PWX_INFLUXPW                Influx password
 
 In your browser visit *http://{IP_ADDRESS}:80* to access your locally running PX-Lighthouse.
 
-![LH-ON-PREM-FIRST-LOGIN](images/lh-on-prem-first-login-updated_2.png "First Login")
+![LH-ON-PREM-FIRST-LOGIN](images/lh-on-prem-first-login-updated_2.png "First Login"){:width="983px" height="707px"}

--- a/run-lighthouse.md
+++ b/run-lighthouse.md
@@ -210,7 +210,7 @@ Runtime command options
 
 In your browser visit *http://{IP_ADDRESS}:80* to access your locally running PX-Lighthouse.
 
-![LH-ON-PREM-FIRST-LOGIN](images/lh-on-prem-first-login-updated_2.png "First Login")
+![LH-ON-PREM-FIRST-LOGIN](images/lh-on-prem-first-login-updated_2.png "First Login"){:width="983px" height="707px"}
 
 
 ### Upgrading PX-Lighthouse
@@ -249,6 +249,6 @@ PX-Lighthouse repository is located [here](https://hub.docker.com/r/portworx/px-
 
 * Make sure you have set inbound security rule to 'Allow' for port 80.
 
-![AZURE-SECURITY-RULES](images/azure-inbound-security-rules.png "Azure Inbound Security Settings")
+![AZURE-SECURITY-RULES](images/azure-inbound-security-rules.png "Azure Inbound Security Settings"){:width="557px" height="183px"}
 
 * Access the web console in browser at http://{public-ip-address}:80

--- a/run-with-docker-ucp.md
+++ b/run-with-docker-ucp.md
@@ -75,6 +75,6 @@ docker  run -d -P -e constraint:pxfabric==px-cluster1 --name db mysql
 
 
 Or, from the UCP GUI for launching a container, specify a constraint for `pxfabric` as follows:
-![UCP GUI constraints](images/constraints.png)
+![UCP GUI constraints](images/constraints.png){:width="791px" height="148px"}
 
 For more information on Docker Filters and Constraints, see [Swarm filters](https://docs.docker.com/swarm/scheduler/filter/).

--- a/run-with-kubernetes.md
+++ b/run-with-kubernetes.md
@@ -328,7 +328,7 @@ Example:
           volumeID: "<vol-id>"
           fsType:   "<fs-type>"
 ```
-Make sure to replace <vol-id>, <size> and <fs-type> in the above spec with
+Make sure to replace &lt;vol-id&gt;, &lt;size&gt; and &lt;fs-type&gt; in the above spec with
 the ones that you used while creating the volume.
 
 [Download example](k8s-samples/portworx-volume-pv.yaml?raw=true)

--- a/run-with-mesosphere.md
+++ b/run-with-mesosphere.md
@@ -23,7 +23,7 @@ Portworx now provides an AWS CloudFormation Template that deploys a Portworx-rea
 
 ## Step 1:  Launch DC/OS CloudFormation Template 
 Click Here:  
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-DCOS-STACK&amp;templateURL=https://s3.amazonaws.com/portworx-dcos-templates/dcos1.9.json" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-DCOS-STACK&amp;templateURL=https://s3.amazonaws.com/portworx-dcos-templates/dcos1.9.json" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
 Specify the EC2 instance type for the Mesos slaves, and the size of the volume (8GB - 4TB) that each slave will contribute
 to the Portworx storage pool.
 

--- a/run-with-mesosphere.md
+++ b/run-with-mesosphere.md
@@ -23,7 +23,7 @@ Portworx now provides an AWS CloudFormation Template that deploys a Portworx-rea
 
 ## Step 1:  Launch DC/OS CloudFormation Template 
 Click Here:  
-<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-DCOS-STACK&amp;templateURL=https://s3.amazonaws.com/portworx-dcos-templates/dcos1.9.json" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px"></a></p>
+<p><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=PX-DCOS-STACK&amp;templateURL=https://s3.amazonaws.com/portworx-dcos-templates/dcos1.9.json" rel="nofollow noreferrer" target="_blank"><img src="https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg" alt="Launch Stack" width="144px" height="27px" class="cf-stack"></a></p>
 Specify the EC2 instance type for the Mesos slaves, and the size of the volume (8GB - 4TB) that each slave will contribute
 to the Portworx storage pool.
 

--- a/run-with-mesosphere.md
+++ b/run-with-mesosphere.md
@@ -98,7 +98,7 @@ You can deploy Portworx using the Mesosphere universe or through Marathon.  Foll
 
 ### To Deploy Portworx through Universe:
 Portworx is now available through the Mesosphere Universe catalog of services.
-![Portworx on Universe](/images/universe.png)
+![Portworx on Universe](/images/universe.png){:width="2047px" height="884px"}
 
 Deploying Portworx through Mesosphere Universe provides great ease of deployment.
 Please follow the published [Mesosphere/DCOS Examples for deploying Portworx through Universe](https://github.com/dcos/examples/tree/master/1.8/portworx) 

--- a/update-lh-password.md
+++ b/update-lh-password.md
@@ -35,4 +35,4 @@ PWX_KVDB_USER_PWD           Username and password for etcd2 as username:password
 ./pwreset 
 ```
 
-![LH-UPDATE-PASSWORD](images/lh-update-password.png "Update Password")
+![LH-UPDATE-PASSWORD](images/lh-update-password.png "Update Password"){:width="1374px" height="986px"}

--- a/volume-sets.md
+++ b/volume-sets.md
@@ -1,4 +1,9 @@
-# Volume Sets
+---
+layout: page
+title: "Volume Sets"
+keywords: portworx, jenkins
+sidebar: home_sidebar
+---
 
 Orchestration software such as mesos allow scaling the number of instances of pods/applications. However, when these pods/applications require data volumes, there is no way to associate instances to data volumes.
 


### PR DESCRIPTION
AMP requires that image have a static size defined as to know the pages layout without pulling additional assets.

List determined with:
```
grep '\!\[' *.md
```

On the site as is, these changes will have **no effect** as the inline rules are superseded by the CSS size definitions.

I did however notice there are some pages where images overflow the page but that happens now and I will raise an issue to that effect. (Edit: #25)

Alongside the images a couple other changes are on the homepage:

 * The buttons for "getting started" have been replaced with a link and the bootstrap `btn` style (as to eliminate the need for forms/buttons. This **does** (and should be the only thing to) have a visual effect.
 * The inline CSS for the fork ribbon has been placed in the CSS file.

Note I may have some other changes to add to this so please don't merge yet.