### PR TITLE
Build with different base.url when AMP generation occurs

### DIFF
--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -9,6 +9,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "gh-pages" ]; 
 
     mv ${BASE}/_layouts/amp.html ${BASE}/_layouts/page.html
 
+    sed -i'' 's/docs.portworx.com/amp-docs.portworx.com/' ${BASE}/_config.yml
+
     bundle exec jekyll build
 
     cd "${BASE}/_site"


### PR DESCRIPTION
This will build the AMP docs with a different base URL so that the redirects work correctly. I am not too sure how useful this will be given redirects are prohibited by AMP but it may help with reindexing.