### PR TITLE
Few broken links

### DIFF
--- a/getting-started/px-developer.md
+++ b/getting-started/px-developer.md
@@ -41,7 +41,7 @@ Run Portworx with schedulers:
 
 Run stateful containers with Docker volumes:
 
-* [Application Solutions](application-solutions.html)
+* [Application Solutions](/application-solutions.html)
 
 Use **pxctl** ([CLI Reference](/control/cli.html)) to directly:
 

--- a/getting-started/px-enterprise.md
+++ b/getting-started/px-enterprise.md
@@ -40,7 +40,7 @@ Run Portworx with schedulers:
 
 Run stateful containers with Docker volumes:
 
-* [Application Solutions](application-solutions.html)
+* [Application Solutions](/application-solutions.html)
 
 Use **pxctl** ([CLI Reference](/control/cli.html)) to directly:
 

--- a/install/coreos.md
+++ b/install/coreos.md
@@ -9,7 +9,7 @@ These instructions are for CoreOS and VMWare Photon.
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](run-etcd.md) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/run-etcd.md) for PX
 
 ### Install and configure Docker
 
@@ -260,7 +260,7 @@ Global Storage Pool
 
 For more on using **pxctl**, see the [CLI Reference](/control/cli.html).
 
-You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](application-solutions.html).
+You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](/application-solutions.html).
 
 ### Adding Nodes
 

--- a/install/docker-plugin.md
+++ b/install/docker-plugin.md
@@ -7,7 +7,7 @@ redirect_from: "/run-as-docker-pluginv2.html"
 ---
 To install and configure PX via the Docker Plugin CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](run-etcd.md) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/run-etcd.md) for PX
 
 ### Install and configure Docker
 
@@ -256,7 +256,7 @@ Global Storage Pool
 
 For more on using **pxctl**, see the [CLI Reference](/control/cli.html).
 
-You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](application-solutions.html).
+You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](/application-solutions.html).
 
 ### Adding Nodes
 

--- a/install/docker.md
+++ b/install/docker.md
@@ -285,7 +285,7 @@ Global Storage Pool
 
 For more on using **pxctl**, see the [CLI Reference](/control/cli.html).
 
-You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](application-solutions.html).
+You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](/application-solutions.html).
 
 ### Adding Nodes
 

--- a/manage/encrypted-volumes.md
+++ b/manage/encrypted-volumes.md
@@ -13,10 +13,10 @@ This guide will give you an overview of how to use Encryption feature for Portwo
 All the encrypted volumes are protected by a key. Portworx uses a passphrase as a key to encrypt volumes. It is recommended to store these passphrases in a secure secret store. Currently Portworx integrates with following Secret endpoints
 
 1. Vault
-To setup Portworx to work with a Vault endpoint follow these [instructions](portworx-with-vault.html)
+To setup Portworx to work with a Vault endpoint follow these [instructions](/portworx-with-vault.html)
 
 2. AWS KMS
-To setup Portworx to work with AWS KMS follow these [instructions](portworx-with-aws-kms.html)
+To setup Portworx to work with AWS KMS follow these [instructions](/portworx-with-aws-kms.html)
 
 ## Creating and using encrypted volumes
 

--- a/portworx-with-mysql-statefulsets.md
+++ b/portworx-with-mysql-statefulsets.md
@@ -18,7 +18,7 @@ Follow [this](/scheduler/kubernetes.html) guide to setup a Portworx and Kubernet
 # kubectl create -f portworx-mysql-sc.yaml
 ````
 
-[Download example](portworx-mysql-sc.yaml?raw=true)
+[Download example](/k8s-samples/portworx-mysql-sc.yaml?raw=true)
 ````
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
@@ -49,7 +49,7 @@ No events.
 # kubectl create -f portworx-mysql-statefulset.yaml
 ````
 
-[Download example](portworx-mysql-statefulset.yaml?raw=true)
+[Download example](/k8s-samples/portworx-mysql-statefulset.yaml?raw=true)
 
 ````
 ---
@@ -173,7 +173,7 @@ Now you can create a mysql Pod to mount the snapshot
 ````
 kubectl create -f portworx-mysql-snap-pod.yaml
 ````
-[Download example](portworx-mysql-snap-pod.yaml?raw=true)
+[Download example](/k8s-samples/portworx-mysql-snap-pod.yaml?raw=true)
 ````
 apiVersion: v1
 kind: Pod

--- a/reference-architecture/docker-datacenter.md
+++ b/reference-architecture/docker-datacenter.md
@@ -100,7 +100,7 @@ Follow the instructions for [Getting Started with Portworx Enterprise](/getting-
 Follow the instructions for [Creating a PX-Enterprise Cluster](create-px-enterprise-cluster.html)
 
 On each of the UCP Nodes, install Portworx **either** through interactive mode by running the [bootstrap curl command](create-px-enterprise-cluster.html#step-2-run-discovery-and-bootstrap-on-a-server-node), 
-**or** in a scripted/autmated method by [running px-enterprise manually](px-usage.html) and using the token-ID from the Lighthouse "Get Startup Script" window.
+**or** in a scripted/autmated method by [running px-enterprise manually](/px-usage.html) and using the token-ID from the Lighthouse "Get Startup Script" window.
 
 ## Step 5: Launch a container
 

--- a/run-with-docker-ent.md
+++ b/run-with-docker-ent.md
@@ -11,7 +11,7 @@ To install and configure PX via the Docker CLI, use the command-line steps in th
 ### Lighthouse
 If you are using the SaaS version of the PX-Enterprise Lighthouse, then we are hosting your metadata for cloud analytics and a GUI interface to manage your cluster.  Please make sure you received the correct token from support@portworx.com.
 
->**Important:**<br/>If you are *NOT* using the Portworx hosted SaaS service for management, then note that PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](run-etcd.md) for PX
+>**Important:**<br/>If you are *NOT* using the Portworx hosted SaaS service for management, then note that PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/run-etcd.html) for PX
 
 ### Install and configure Docker
 
@@ -284,7 +284,7 @@ Global Storage Pool
 
 For more on using **pxctl**, see the [CLI Reference](/control/cli.html).
 
-You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](application-solutions.html).
+You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](/application-solutions.html).
 
 ### Adding Nodes
 

--- a/scheduler/kubernetes.md
+++ b/scheduler/kubernetes.md
@@ -139,7 +139,7 @@ Example:
        snap_interval:   "70"
        io_priority:  "high"
 ```
-[Download example](k8s-samples/portworx-volume-sc-high.yaml?raw=true)
+[Download example](/k8s-samples/portworx-volume-sc-high.yaml?raw=true)
 
 Verifying storage class is created:
 
@@ -520,7 +520,7 @@ a pre-provisioned volume and not a PVC you will replace the key with PV name lik
 
 ## Additional examples of Kubernetes and Portworx
 
-* [Portworx with mysql Statefulsets](portworx-with-mysql-statefulsets.html)
+* [Portworx with mysql Statefulsets](/portworx-with-mysql-statefulsets.html)
 
 ## Bill of Materials on Public Cloud Providers
 Use [this](/k8s-pwx-bom.html) guide to calculate the BOM for a complete Kubernetes with Portworx compute and storage environment for running stateful applications.

--- a/scheduler/mesosphere-dcos/cassandra.md
+++ b/scheduler/mesosphere-dcos/cassandra.md
@@ -13,7 +13,7 @@ repositories to your DCOS cluster to install the services mentioned here.
 The source code for these services can be found here: https://github.com/portworx/dcos-commons
 This is a fork from [Mesos DCOS-commons framework](https://github.com/mesosphere/dcos-commons) and we will pull in updates from there regularly.
 
-Please make sure you have installed [Portworx on DCOS](run-with-mesosphere.md) before proceeding further.
+Please make sure you have installed [Portworx on DCOS](/scheduler/mesosphere-dcos/install.html) before proceeding further.
 
 ## Adding the repository for the service:
 

--- a/scheduler/mesosphere-dcos/hadoop-hdfs.md
+++ b/scheduler/mesosphere-dcos/hadoop-hdfs.md
@@ -15,7 +15,7 @@ repositories to your DCOS cluster to install the services mentioned here.
 The source code for these services can be found here: https://github.com/portworx/dcos-commons
 This is a fork from [Mesos DCOS-commons framework](https://github.com/mesosphere/dcos-commons) and we will pull in updates from there regularly.
 
-Please make sure you have installed [Portworx on DCOS](run-with-mesosphere.md) before proceeding further.
+Please make sure you have installed [Portworx on DCOS](/scheduler/mesosphere-dcos/install.html) before proceeding further.
 
 ## Adding the repository for the service:
 


### PR DESCRIPTION
There are the ones I could find with a quick grep.

Ones I didn't know how to resolve:

```
./reference-architecture/docker-datacenter.md:Follow the instructions for [Creating a PX-Enterprise Cluster](create-px-enterprise-cluster.html)
./reference-architecture/docker-datacenter.md:On each of the UCP Nodes, install Portworx **either** through interactive mode by running the [bootstrap curl command](create-px-enterprise-cluster.html#step-2-run-discovery-and-bootstrap-on-a-server-node),
./HOW_TO_DOCS.md:[Create a PX-Enterprise Cluster](create-px-enterprise-cluster.html)  <br/>
```