### PR TITLE
Add a sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,3 +113,4 @@ google_analytics: UA-64247527-1
 
 gems:
   - jekyll-redirect-from
+  - jekyll-sitemap


### PR DESCRIPTION
From what I can tell this is literally all that is required. `jekyll-sitemap` is compatible with Github Pages.

This only includes the minimum required so there may be room for improvement in the future.