### PR TITLE
Only build once

### DIFF
--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -16,6 +16,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "gh-pages" ]; 
     cd "${BASE}/_site"
 
     echo "amp-docs.portworx.com" > CNAME
+    touch .nojekyll
 
     git init
 


### PR DESCRIPTION
When a build occurs for AMP, it happens on Travis and is pushed to Github. There is no need for another build to happen on Github pages, and this results in build failure messages.