### PR TITLE
add examples section to DCOS

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -38,8 +38,10 @@
           url: /scheduler/mesosphere-dcos/cassandra.html
         - title: HDFS & Hadoop
           url: /scheduler/mesosphere-dcos/hadoop-hdfs.html   
-      - title: Scaling Stateful Applications
-        url: /scheduler/mesosphere-dcos/volume-scaling.html
+      - title: Examples
+        folderitems:
+        - title: Scaling stateful applications
+          url: /scheduler/mesosphere-dcos/volume-scaling.html
     - title: Docker
       folderitems:
       - title: Install


### PR DESCRIPTION
Put the scaling volumes articles into an "examples" section where we can add other content.