### PR TITLE
Quick fix for mobile nav

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,9 +7,7 @@
 
 <link rel="preload" href="/css/bundle.css" as="style" onload="this.rel='stylesheet'">
 
-<noscript>
     <link rel="stylesheet" href="/css/bundle.css" />
-</noscript>
 
 <!-- This needs some minification -->
 <style type="text/css">


### PR DESCRIPTION
For some reason mobiles are not loading the full stylesheet (maybe others) this should be added back in when fixed to improve pagespeed enhancements again.