### PR TITLE
Remove troubleshooting link from menu

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -234,8 +234,6 @@
       url: /knowledgebase/sles-12-sp1.html
     - title: FAQs
       url: /knowledgebase/faqs.html
-    - title: Troubleshooting
-      url: /knowledgebase/troubleshooting.html
   - title: Release Notes
     folderitems:
     - title: About 1.x


### PR DESCRIPTION
Page was removed here https://github.com/portworx/px-docs/commit/eaf18cd6ae10282b9ddb6427d9d209e95e805bc1