### PR TITLE
Meta descriptions support in front matter

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-<meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
 
@@ -42,4 +41,8 @@
 
 {% if site.google_analytics and jekyll.environment == 'production' %}
 {% include google_analytics.html %}
+{% endif %}
+
+{% if page.meta-description %}
+    <meta name="description" content="{{ page.meta-description }}"/>
 {% endif %}


### PR DESCRIPTION
Remove old (potentially blanking) meta description and replace with a 'meta-description' property of a page's front matter