### PR TITLE
Set, not send the content group

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -9,7 +9,7 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ site.google_analytics }}', 'auto');
-  ga('send', 'contentGroup1', '{{ page.title }}');
+  ga('set', 'contentGroup1', '{{ page.title }}');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
https://support.google.com/analytics/answer/2853546?hl=en

I believe the incorrect function is being called. This will cause issues setting the Analytics content grouping.