### PR TITLE
Fix navigation highlighting on index.html pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,10 +1,11 @@
 {% assign navurl = page.url | remove: 'index.html' %}
 <ul id="mysidebar" class="nav">
 {% for item in include.nav %}
+    {% assign currenturl = item.url | remove: 'index.html' %}
     <li {% if item.folderitems %}class="submenu"{% endif %}>
         <a href="{% if item.url and item.folderitems == null %}{{ item.url }}{% else %}#{% endif %}" 
-            {% if item.url == navurl %}class="selected"{% endif %}>
-            {% if item.url == navurl %}
+            {% if currenturl == navurl %}class="selected"{% endif %}>
+            {% if currenturl == navurl %}
                 <b>{{ item.title }}</b>
             {% else %}
                 {{ item.title }}


### PR DESCRIPTION
Strip out html from looped path so that it matches that of the current page URL (which is also trimmed)