### PR TITLE
Point to the new etcd installation instructions.

### DIFF
--- a/cloud/aws/ecs.md
+++ b/cloud/aws/ecs.md
@@ -27,7 +27,7 @@ Log into the ECS console and create an ecs cluster called "ecs-demo1".
 ![ecs-clust-create](/images/aws-ecs-setup_withPX_001y.PNG "ecs-1"){:width="1023px" height="928px"}.
 
 
-On above, the Container Instance IAM role is used by the ECS container agent. These ECS container agent is deployed by default with the EC2 instances from the ECS wizard. And these agent makes call to AWS ECS API actions on your behalf, thus these EC2 instances that running the ECS container agent require an IAM role that has permission to join ECS cluster and launch containers within the cluster. 
+On above, the Container Instance IAM role is used by the ECS container agent. These ECS container agent is deployed by default with the EC2 instances from the ECS wizard. And these agent makes call to AWS ECS API actions on your behalf, thus these EC2 instances that running the ECS container agent require an IAM role that has permission to join ECS cluster and launch containers within the cluster.
 
 Create a custom IAM role and Select Role Type "Amazon EC2 Role for Container Service". This is the minimal required permission to launch ECS cluster. And depends on your use case, you may need additional AWS policy for your ECS to access and use other AWS resources. The "AmazonEC2ContainerServiceRole" has the policy shown below:
 
@@ -58,7 +58,7 @@ Your EC2 instances must have the correct IAM role set.  Follow these [IAM instru
 
 
 
-After the ECS cluster "ecs-demo1" successfully launched, the corresponding EC2 instances that belong to this ECS cluster can be found under the "ECS instance" tab of ECS console or from AWS EC2 console. Each of this EC2 instance is running with an amazon-ecs-agent in docker container. 
+After the ECS cluster "ecs-demo1" successfully launched, the corresponding EC2 instances that belong to this ECS cluster can be found under the "ECS instance" tab of ECS console or from AWS EC2 console. Each of this EC2 instance is running with an amazon-ecs-agent in docker container.
 
 ![ecs-clust-create](/images/aws-ecs-setup_withPX_003xx.PNG "ecs-3"){:width="1723px" height="863px"}.
 
@@ -70,7 +70,7 @@ Provisioning storage to these EC2 instances by creating new EBS volumes and atta
 
 ![ecs-clust-create](/images/aws-ecs-setup_withPX_004yy.PNG "ecs-4"){:width="1477px" height="699px"}.
 
-Note that there is no need to format the EBS volumes once they are created and attached to the ec2 instance. Portworx will pick up the available unformatted drives (if you use the -a option as show below in the next step) or you can point to the appropriate block device for the Portworx to pick up by using the -s option when you launch Portworx with the docker run command. 
+Note that there is no need to format the EBS volumes once they are created and attached to the ec2 instance. Portworx will pick up the available unformatted drives (if you use the -a option as show below in the next step) or you can point to the appropriate block device for the Portworx to pick up by using the -s option when you launch Portworx with the docker run command.
 
 
 ### Step 2: Deploy Portworx
@@ -89,11 +89,9 @@ ssh into each of the EC2 instances and configure docker for shared mount on "/"
 
 Run Portworx on each ECS instance.  Portworx will use the EBS volumes you provisioned in step 4.
 
-Portworx requires a 3-node etcd cluster to be running for storing cluster configuration. 
+Portworx requires a 3-node etcd cluster to be running for storing cluster configuration.
 
-Follow the instructions here for spinning up a [etcd cluster](https://coreos.com/etcd/docs/latest/op-guide/clustering.html)
-
-Also, the ansible playbook here can be used to spin up a [3 node etcd cluster](https://github.com/portworx/px-docs/tree/gh-pages/etcd/ansible). Make sure to have three ec2 instances provisioned and root ssh keys are installed in all the servers
+Follow the instructions here for spinning up a [etcd cluster](/maintain/etcd.md)
 
 Launch PX containers, you will have to log into each of ECS instance and run the following command for this step. Change the etcd IP and cluster ID for your PX cluster deployment.
 
@@ -119,15 +117,15 @@ In the example above, we are using the -a option which will pick up all the avai
 
 
 ### Step 3: Setup ECS task with PX volume from ECS CLI workstation
-From your linux workstation download and setup AWS ECS CLI utilities 
+From your linux workstation download and setup AWS ECS CLI utilities
 
   1. Download and install ECS CLI ([detail instructions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html))
-  
+
          $ sudo curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest
          $ sudo chmod +x /usr/local/bin/ecs-cli
 
   2. Configure AWS ECS CLI on your workstation
-     
+
          $ export AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXX
          $ export AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXX
          $ ecs-cli configure --region us-east-1 --access-key $AWS_ACCESS_KEY_ID --secret-key $AWS_SECRET_ACCESS_KEY --cluster ecs-demo1
@@ -136,7 +134,7 @@ From your linux workstation download and setup AWS ECS CLI utilities
 
 
          $ ssh -i ~/.ssh/id_rsa ec2-user@52.91.191.220
-         $ docker volume create -d pxd --name=demovol --opt size=1 --opt repl=3 --opt shared=true 
+         $ docker volume create -d pxd --name=demovol --opt size=1 --opt repl=3 --opt shared=true
          demovol
 
          $ docker volume ls
@@ -156,8 +154,8 @@ From your linux workstation download and setup AWS ECS CLI utilities
          image: redis
          volumes:
            -  demovol:/data
-           -  
-         $ ecs-cli compose --file redis.yml up 
+           -
+         $ ecs-cli compose --file redis.yml up
          INFO[0001] Using ECS task definition                     TaskDefinition="ecscompose-root:1"
          INFO[0001] Starting container...                         container="59701c44-c267-4c85-a8c0-ff87910af535/web"
          INFO[0001] Starting container...                         container="59701c44-c267-4c85-a8c0-ff87910af535/redis"
@@ -176,17 +174,17 @@ From your linux workstation download and setup AWS ECS CLI utilities
   6. On the above ECS console, Clusters -> pick your cluster ```ecs-demo1``` and click on the ```Container Instance``` ID that corresponding to the running task. This will display the containers information including where are these containers deployed into which EC2 instance. Below, we find that the task defined containers are deployed on EC2 instance with public IP address ```52.91.191.220```.
 ![task](/images/aws-ecs-setup_withPX_003z.PNG "ecs3z"){:width="1136px" height="598px"}
   7. From above, ssh into the EC2 instance 52.91.191.220 and verify PX volume is attached to running container.
-         
+
          [ec2-user@ip-172-31-31-61 ~]$ sudo docker ps -a
          CONTAINER ID        IMAGE                            COMMAND                  CREATED             STATUS              PORTS                                             NAMES
          7ba93d51918b        binocarlos/moby-counter          "node index.js"          12 hours ago        Up 12 hours         80/tcp                                            ecs-ecscompose-root-1-web-c2fbfff3bf92b1dad401
-         e25ba9131f9b        redis                            "docker-entrypoint.sh"   12 hours ago        Up 12 hours         6379/tcp                                          ecs-ecscompose-root-1-redis-a6a6a2fcb4a6d188e601         
+         e25ba9131f9b        redis                            "docker-entrypoint.sh"   12 hours ago        Up 12 hours         6379/tcp                                          ecs-ecscompose-root-1-redis-a6a6a2fcb4a6d188e601
 
          [ec2-user@ip-172-31-31-61 ~]$ sudo /opt/pwx/bin/pxctl v l
          ID                      NAME                    SIZE    HA      SHARED  ENCRYPTED       IO_PRIORITY     SCALE   STATUS
          1061916907972944739     demovol                 1 GiB   3       yes     no              LOW             0       up - attached on 172.31.31.61
    8. Check the redis container ```ecs-ecscompose-root-1-redis-a6a6a2fcb4a6d188e601``` and verify a 1GB pxfs volume is mounted on /data
-  
+
           [ec2-user@ip-172-31-31-61 ~]$ sudo docker exec -it ecs-ecscompose-root-1-redis-a6a6a2fcb4a6d188e601 sh -c 'df -kh'
           Filesystem                                                                                        Size  Used Avail Use% Mounted on
           /dev/mapper/docker-202:1-263203-3f7e353e23d7ba722fc74d1fb7db60e34f98933355ac65f78e6b4f2bcde19778  9.8G  215M  9.0G   3% /
@@ -195,21 +193,21 @@ From your linux workstation download and setup AWS ECS CLI utilities
           pxfs                                                                                              976M  2.5M  907M   1% /data
           /dev/xvda1                                                                                        7.8G  1.3G  6.5G  16% /etc/hosts
           shm                                                                                                64M     0   64M   0% /dev/shm
-         
-    
+
+
 
 ### Step 4: Setup ECS task with PX volume via AWS ECS console
-#### Optional: the same process of step3 but do it on AWS GUI 
+#### Optional: the same process of step3 but do it on AWS GUI
 
 Create a ECS tasks definition directly via the ECS console (GUI) and using PX volume.
 
-  1. ssh into one of the EC2 instance and create a new PX volume using Docker CLI. 
+  1. ssh into one of the EC2 instance and create a new PX volume using Docker CLI.
 
           $ docker volume create -d pxd --name=demovol --opt size=1 --opt repl=3 --opt shared=true
 
 
   2. In AWS ECS console, choose the previously created cluster ```ecs-demo1```; then create a new task definition.
- 
+
    ![task](/images/aws-ecs-setup_withPX_005y.PNG){:width="1345px" height="594px"}
   3. From the new task definition screen, enter the task definition name ```redis-demo``` and click ```Add volume``` near the bottom of the page.
   ![task](/images/aws-ecs-setup_withPX_005yy.PNG){:width="1404px" height="777px"}
@@ -229,5 +227,4 @@ Create a ECS tasks definition directly via the ECS console (GUI) and using PX vo
   ![task](/images/aws-ecs-setup_withPX_010y.PNG){:width="1304px" height="713px"}
   11. You will see the task is submitted and change status from ```PENDING``` to ```RUNNING```.
   ![task](/images/aws-ecs-setup_withPX_011y.PNG){:width="1157px" height="598px"}
-  ![task](/images/aws-ecs-setup_withPX_012y.PNG){:width="1570px" height="640px"}  
-  
+  ![task](/images/aws-ecs-setup_withPX_012y.PNG){:width="1570px" height="640px"}

--- a/cloud/aws/ecs.md
+++ b/cloud/aws/ecs.md
@@ -91,7 +91,7 @@ Run Portworx on each ECS instance.  Portworx will use the EBS volumes you provis
 
 Portworx requires a 3-node etcd cluster to be running for storing cluster configuration.
 
-Follow the instructions here for spinning up a [etcd cluster](/maintain/etcd.md)
+Follow the instructions here for spinning up a [etcd cluster](/maintain/etcd.html)
 
 Launch PX containers, you will have to log into each of ECS instance and run the following command for this step. Change the etcd IP and cluster ID for your PX cluster deployment.
 

--- a/enterprise/on-premise-lighthouse.md
+++ b/enterprise/on-premise-lighthouse.md
@@ -31,7 +31,7 @@ sudo docker run --restart=always                                        \
        -p 80:80                                                         \
        portworx/px-lighthouse                                           \
        -d http://${ADMIN_USER}:${ADMIN_PASSWORD}@${IP_ADDR}:8086        \
-       -k etcd:http://${KVDB_IP_ADDR}:2379                
+       -k etcd:http://${KVDB_IP_ADDR}:2379
 ```
 
 For **Consul**, start the container with the following run command:
@@ -41,7 +41,7 @@ sudo docker run --restart=always --name px-lighthouse -d --net=bridge    \
        -p 80:80                                                          \
        portworx/px-lighthouse                                            \
        -d http://${ADMIN_USER}:${ADMIN_PASSWORD}@${IP_ADDR}:8086         \
-       -k consul:http://${KVDB_IP_ADDR}:8500                
+       -k consul:http://${KVDB_IP_ADDR}:8500
 ```
 
 Runtime command options
@@ -52,7 +52,7 @@ Runtime command options
 -k {etcd/consul}:http://{IP_Address}:{Port_NO}
    > Connection string of your kbdb.
    > Note: Specify port 2379 for etcd and 8500 for consul
-   > If you have multinode etcd cluster then you can specify your connection string as 
+   > If you have multinode etcd cluster then you can specify your connection string as
        > 'etcd:http://{KVDB_IP_ADDR_1}:2379,etcd:http://{KVDB_IP_ADDR_2}:2379,etcd:http://{KVDB_IP_ADDR_3}:2379'
 ```
 
@@ -86,10 +86,10 @@ sudo docker run --restart=always --name px-lighthouse -d --net=bridge    \
        -p 80:80                                                          \
        portworx/px-lighthouse                                            \
        -d http://${ADMIN_USER}:${ADMIN_PASSWORD}@${IP_ADDR}:8086         \
-       -k consul:http://${KVDB_IP_ADDR}:8500   
+       -k consul:http://${KVDB_IP_ADDR}:8500
 ```
 
-PX-Lighthouse repository is located [here](https://hub.docker.com/r/portworx/px-lighthouse/). Above mentioned docker commands will upgrade your PX-Lighthouse container to the latest release. There should be minimal downtime in this upgrade process. 
+PX-Lighthouse repository is located [here](https://hub.docker.com/r/portworx/px-lighthouse/). Above mentioned docker commands will upgrade your PX-Lighthouse container to the latest release. There should be minimal downtime in this upgrade process.
 
 ### Provider Specific Instructions
 

--- a/getting-started/px-developer.md
+++ b/getting-started/px-developer.md
@@ -17,7 +17,7 @@ meta-description: "Getting started with PX-Developer? In just two steps, Portwor
 * Configure Docker to use shared mounts.  The shared mounts configuration is required, as PX-Developer exports mount points.
   * Run sudo mount --make-shared / in your SSH window
   * If you are using systemd, remove the `MountFlags=slave` line in your docker.service file.
-* A kev/value store such as Etcd 2.0 or Consul 0.7.0
+* A kev/value store such as Etcd 3.0 or Consul 0.7.0
 * Minimum resources per server:
   * 4 CPU cores
   * 4 GB RAM

--- a/getting-started/px-developer.md
+++ b/getting-started/px-developer.md
@@ -17,7 +17,7 @@ meta-description: "Getting started with PX-Developer? In just two steps, Portwor
 * Configure Docker to use shared mounts.  The shared mounts configuration is required, as PX-Developer exports mount points.
   * Run sudo mount --make-shared / in your SSH window
   * If you are using systemd, remove the `MountFlags=slave` line in your docker.service file.
-* A kev/value store such as Etcd 3.0 or Consul 0.7.0
+* A key/value store such as Etcd 3.0 or Consul 0.7.0
 * Minimum resources per server:
   * 4 CPU cores
   * 4 GB RAM

--- a/getting-started/px-enterprise.md
+++ b/getting-started/px-enterprise.md
@@ -17,7 +17,7 @@ redirect_from:
 * Configure Docker to use shared mounts.  The shared mounts configuration is required, as PX-Enterprise exports mount points.
   * Run sudo mount --make-shared / in your SSH window
   * If you are using systemd, remove the `MountFlags=slave` line in your docker.service file.
-* A kev/value store such as Etcd 2.0 or Consul 0.7.0
+* A kev/value store such as Etcd 3.0 or Consul 0.7.0
 * Minimum resources per server:
   * 4 CPU cores
   * 4 GB RAM

--- a/getting-started/px-enterprise.md
+++ b/getting-started/px-enterprise.md
@@ -17,7 +17,7 @@ redirect_from:
 * Configure Docker to use shared mounts.  The shared mounts configuration is required, as PX-Enterprise exports mount points.
   * Run sudo mount --make-shared / in your SSH window
   * If you are using systemd, remove the `MountFlags=slave` line in your docker.service file.
-* A kev/value store such as Etcd 3.0 or Consul 0.7.0
+* A key/value store such as Etcd 3.0 or Consul 0.7.0
 * Minimum resources per server:
   * 4 CPU cores
   * 4 GB RAM

--- a/install/coreos.md
+++ b/install/coreos.md
@@ -13,8 +13,8 @@ These instructions are for CoreOS and VMWare Photon.
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set 
-one up, see the [etcd example](/run-etcd.html) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set
+one up, see the [etcd example](/maintain/etcd.md) for PX
 
 ### Install and configure Docker
 
@@ -145,13 +145,13 @@ https://raw.githubusercontent.com/portworx/px-dev/master/conf/config.json
    ```
    # sudo mkdir -p /etc/pwx
    ```
-   
+
 3. Move the configuration file to that directory. This directory later gets passed in on the Docker command line.
 
    ```
    # sudo cp -p config.json /etc/pwx
    ```
-   
+
 4. Edit the config.json to include the following:
    * `clusterid`: This string identifies your cluster and must be unique within your etcd key/value space.
    * `kvdb`: This is the etcd connection string for your etcd key/value store.

--- a/install/coreos.md
+++ b/install/coreos.md
@@ -13,7 +13,7 @@ These instructions are for CoreOS and VMWare Photon.
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. We recommend setting up a dedicated kvdb for PX to use.  If you want to set
 one up, see the [etcd example](/maintain/etcd.html) for PX
 
 ### Install and configure Docker

--- a/install/coreos.md
+++ b/install/coreos.md
@@ -14,7 +14,7 @@ These instructions are for CoreOS and VMWare Photon.
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
 >**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set
-one up, see the [etcd example](/maintain/etcd.md) for PX
+one up, see the [etcd example](/maintain/etcd.html) for PX
 
 ### Install and configure Docker
 

--- a/install/docker.md
+++ b/install/docker.md
@@ -12,7 +12,7 @@ redirect_from:
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.html) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. We recommend setting up a dedicated kvdb for PX to use. If you want to set one up, see the [etcd example](/maintain/etcd.html) for PX
 
 ### Install and configure Docker
 

--- a/install/docker.md
+++ b/install/docker.md
@@ -12,7 +12,7 @@ redirect_from:
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/run-etcd.html) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.md) for PX
 
 ### Install and configure Docker
 
@@ -78,20 +78,20 @@ Where the following arguments are provided to the PX daemon:
 
 -k
 	> Points to your key value database, such as an etcd cluster or a consul cluster.
-	
+
 -userpwd
        > username and password for ETCD authentication in the form <user_name>:<passwd>
- 
+
 -ca
        > location of CA file for ETCD authentication
-       
--cert 
+
+-cert
 	> location of certificate for ETCD authentication
 
--key 
+-key
 	> location of certificate key for ETCD authentication
 
--acltoken 
+-acltoken
 	> ACL token value used for Consul authentication
 
 -c
@@ -161,13 +161,13 @@ https://raw.githubusercontent.com/portworx/px-dev/master/conf/config.json
    ```
    # sudo mkdir -p /etc/pwx
    ```
-   
+
 3. Move the configuration file to that directory. This directory later gets passed in on the Docker command line.
 
    ```
    # sudo cp -p config.json /etc/pwx
    ```
-   
+
 4. Edit the config.json to include the following:
    * `clusterid`: This string identifies your cluster and must be unique within your etcd key/value space.
    * `kvdb`: This is the etcd connection string for your etcd key/value store.

--- a/install/docker.md
+++ b/install/docker.md
@@ -12,7 +12,7 @@ redirect_from:
 
 To install and configure PX via the Docker CLI, use the command-line steps in this section.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.md) for PX
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.html) for PX
 
 ### Install and configure Docker
 

--- a/run-air-gap.md
+++ b/run-air-gap.md
@@ -8,7 +8,7 @@ sidebar: home_sidebar
 Environments that do not permit any outside connectivity are considered an "air-gap" environment.
 Such environments preclude the use PX-Enterprise "Lighthouse" console, but can still run PX-Developer or PX-Enterprise.
 There are 3 main requirements
-- Run a local version of 'etcd'
+- Run a local version of 'etcd'. For etcd installation instructions refer this [doc](/maintain/etcd.md)
 - Create a customer 'config.json' file
 - Launch PX-Entprise manually
 
@@ -41,7 +41,7 @@ An absolute minimal configuration would look like this:
     ],
     "storage": {
         "devices": [
-            "/dev/sdX",   
+            "/dev/sdX",
             "/dev/sdY"
         ]
     },

--- a/run-air-gap.md
+++ b/run-air-gap.md
@@ -8,7 +8,7 @@ sidebar: home_sidebar
 Environments that do not permit any outside connectivity are considered an "air-gap" environment.
 Such environments preclude the use PX-Enterprise "Lighthouse" console, but can still run PX-Developer or PX-Enterprise.
 There are 3 main requirements
-- Run a local version of 'etcd'. For etcd installation instructions refer this [doc](/maintain/etcd.md)
+- Run a local version of 'etcd'. For etcd installation instructions refer this [doc](/maintain/etcd.html)
 - Create a customer 'config.json' file
 - Launch PX-Entprise manually
 

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -27,7 +27,7 @@ Before installing the plugin, please:
 
    * these directories are no longer created automatically via v2 Docker plugin, but will be required so that PX-plugin can export ```pxctl``` CLI onto the host, share configuration files, etc.
 
-2. Make sure you have your key-value database ready (ie. preinstall `etcd`). For etcd installation instructions refer this [doc](../maintain/etcd.md).
+2. Make sure you have your key-value database ready (ie. preinstall `etcd`). For etcd installation instructions refer this [doc](/maintain/etcd.html).
 
 3. Ensure host system has some extra disk-storage (ie. `/dev/sdc` disk).
 

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -27,7 +27,7 @@ Before installing the plugin, please:
 
    * these directories are no longer created automatically via v2 Docker plugin, but will be required so that PX-plugin can export ```pxctl``` CLI onto the host, share configuration files, etc.
 
-2. Make sure you have your key-value database ready (ie. preinstall `etcd`), and
+2. Make sure you have your key-value database ready (ie. preinstall `etcd`). For etcd installation instructions refer this [doc](../maintain/etcd.md).
 
 3. Ensure host system has some extra disk-storage (ie. `/dev/sdc` disk).
 
@@ -66,7 +66,7 @@ The required permissions are explained below:
  - mount: [/dev]
  - allow-all-devices: [true]
     > Allows PX to access all host devices. Note that PX uses only devices/drives specified via `-s /dev/xxx` in opts or config.json.
-    
+
  - mount: [/etc/pwx]
     > the configuration files location.
 
@@ -201,13 +201,13 @@ https://raw.githubusercontent.com/portworx/px-dev/master/conf/config.json
    ```
    # sudo mkdir -p /etc/pwx
    ```
-   
+
 3. Move the configuration file to that directory. This directory later gets passed in on the Docker command line.
 
    ```
    # sudo cp -p config.json /etc/pwx
    ```
-   
+
 4. Edit the config.json to include the following:
    * `clusterid`: This string identifies your cluster and must be unique within your etcd key/value space.
    * `kvdb`: This is the etcd connection string for your etcd key/value store.

--- a/scheduler/docker/install-standalone.md
+++ b/scheduler/docker/install-standalone.md
@@ -12,7 +12,7 @@ redirect_from:
 
 This guide describes installing Portworx using the docker CLI.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/run-etcd.html) for PX. Ensure all nodes running PX are synchronized in time and NTP is configured
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.md) for PX. Ensure all nodes running PX are synchronized in time and NTP is configured
 
 
 ## Install and configure Docker
@@ -55,9 +55,9 @@ If you are running Docker version 1.12 or prior, you can run PX as a Docker cont
 To add nodes to increase capacity and enable high availability, simply repeat these steps on other servers.  As long as PX is started with the same cluster ID, they will form a cluster.
 
 ## Access the pxctl CLI
-After Portworx is running, you can create and delete storage volumes through the Docker volume commands or the **pxctl** command line tool. 
+After Portworx is running, you can create and delete storage volumes through the Docker volume commands or the **pxctl** command line tool.
 
-With **pxctl**, you can also inspect volumes, the volume relationships with containers, and nodes. For more on using **pxctl**, see the [CLI 
+With **pxctl**, you can also inspect volumes, the volume relationships with containers, and nodes. For more on using **pxctl**, see the [CLI
 Reference](/control/status.html).
 
 To view the global storage capacity, run:

--- a/scheduler/docker/install-standalone.md
+++ b/scheduler/docker/install-standalone.md
@@ -12,7 +12,7 @@ redirect_from:
 
 This guide describes installing Portworx using the docker CLI.
 
->**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.md) for PX. Ensure all nodes running PX are synchronized in time and NTP is configured
+>**Important:**<br/>PX stores configuration metadata in a KVDB (key/value store), such as Etcd or Consul. If you have an existing KVDB, you may use that.  If you want to set one up, see the [etcd example](/maintain/etcd.html) for PX. Ensure all nodes running PX are synchronized in time and NTP is configured
 
 
 ## Install and configure Docker

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -20,7 +20,7 @@ Portworx can run alongside Kubernetes and provide Persistent Volumes to other ap
 ![k8s porx Logo](/images/k8s-porx.png){:height="188px" width="188px"}
 
 ## Deploy PX with Kubernetes 1.6+
-Kubernetes-1.6 [release](https://github.com/kubernetes/kubernetes/releases/tag/v1.6.0) includes the Portworx native driver support which allows Dynamic Volume Provisioning. 
+Kubernetes-1.6 [release](https://github.com/kubernetes/kubernetes/releases/tag/v1.6.0) includes the Portworx native driver support which allows Dynamic Volume Provisioning.
 
 The native portworx driver in Kubernetes supports the following features:
 1. Dynamic Volume Provisioning
@@ -35,11 +35,11 @@ The native portworx driver in Kubernetes supports the following features:
 * You *must* configure Docker to allow shared mounts propogation. Please follow [these](/knowledgebase/shared-mount-propogation.html) instructions to enable shared mount propogation.  This is needed because PX runs as a container and it will be provisioning storage to other containers.
 * Ensure ports 9001-9004 are open between the Kubernetes nodes that will run Portworx.
 * Ensure all nodes running PX are synchronized in time and NTP is configured
-* A clustered key-value database (etcd or consul) https://coreos.com/etcd/docs/latest/op-guide/clustering.html
+* A clustered key-value database (etcd or consul). For etcd installation instructions refer this [doc](../maintain/etcd.md).
 
 ## Install
 
-PX can be deployed with a single command in Kubernetes as a `DaemonSet` with the following: 
+PX can be deployed with a single command in Kubernetes as a `DaemonSet` with the following:
 ```
 # Download the spec - substitute your parameters below.
 K8S_VERSION=`kubectl version --short | grep Server | awk '{print $3}'`

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -35,7 +35,7 @@ The native portworx driver in Kubernetes supports the following features:
 * You *must* configure Docker to allow shared mounts propogation. Please follow [these](/knowledgebase/shared-mount-propogation.html) instructions to enable shared mount propogation.  This is needed because PX runs as a container and it will be provisioning storage to other containers.
 * Ensure ports 9001-9004 are open between the Kubernetes nodes that will run Portworx.
 * Ensure all nodes running PX are synchronized in time and NTP is configured
-* A clustered key-value database (etcd or consul). For etcd installation instructions refer this [doc](../maintain/etcd.md).
+* A clustered key-value database (etcd or consul). For etcd installation instructions refer this [doc](/maintain/etcd.html).
 
 ## Install
 

--- a/scheduler/kubernetes/support.md
+++ b/scheduler/kubernetes/support.md
@@ -14,7 +14,7 @@ meta-description: "For troubleshooting PX on Kubernetes, Portworx can help. Read
 Following sections will guide you in troubleshooting issues with your Portworx installation on Kubernetes.
 
 ### Etcd
-* Px container will fail to come up if it cannot reach etcd. For etcd installation instructions refer this [doc](../maintain/etcd.md).
+* Px container will fail to come up if it cannot reach etcd. For etcd installation instructions refer this [doc](/maintain/etcd.html).
   * The etcd location specified when creating the Portworx cluster needs to be reachable from all nodes.
   * Run `curl <etcd_location>/version` from each node to ensure reachability. For e.g `curl http://192.168.33.10:2379/version`
 * If you deployed etcd as a Kubernetes service, use the ClusterIP instead of the kube-dns name. Portworx nodes cannot resolve kube-dns entries since px containers are in the host network.

--- a/scheduler/kubernetes/support.md
+++ b/scheduler/kubernetes/support.md
@@ -14,9 +14,10 @@ meta-description: "For troubleshooting PX on Kubernetes, Portworx can help. Read
 Following sections will guide you in troubleshooting issues with your Portworx installation on Kubernetes.
 
 ### Etcd
-* Px container will fail to come up if it cannot reach etcd. The etcd location specified when creating the Portworx cluster needs to be reachable from all nodes.
+* Px container will fail to come up if it cannot reach etcd. For etcd installation instructions refer this [doc](../maintain/etcd.md).
+  * The etcd location specified when creating the Portworx cluster needs to be reachable from all nodes.
   * Run `curl <etcd_location>/version` from each node to ensure reachability. For e.g `curl http://192.168.33.10:2379/version`
-* If you deployed etcd as a Kubernetes service, use the ClusterIP instead of the kube-dns name. Portworx nodes cannot resolve kube-dns entries since px containers are in the host network. 
+* If you deployed etcd as a Kubernetes service, use the ClusterIP instead of the kube-dns name. Portworx nodes cannot resolve kube-dns entries since px containers are in the host network.
 
 ### Portworx cluster
 * If the px container is failing to start on each node, ensure you have shared mounts enable. Please follow [these](/knowledgebase/shared-mount-propogation.html) instructions to enable shared mount propogation.  This is needed because PX runs as a container and it will be provisioning storage to other containers.
@@ -76,4 +77,3 @@ We are always available on Slack. Join us! [![](/images/slack.png){:height="48px
 This issue is observed when using dynamically provisioned Portworx volumes using a StorageClass. If you are using pre-provisioned volumes, you can ignore this issue.
 * To workaround this, you need to set `hostNetwork: true` in the spec file `modules/bootkube/resources/manifests/kube-controller-manager.yaml` and then run the tectonic installer to deploy kubernetes.
 * Here is a sample [kube-controller-manager.yaml](https://gist.github.com/harsh-px/106a23b702da5c86ac07d2d08fd44e8d) after the workaround.
-

--- a/scheduler/mesosphere-dcos/install.md
+++ b/scheduler/mesosphere-dcos/install.md
@@ -16,7 +16,7 @@ This DCOS service will deploy Portworx as well as all the dependencies and addit
 cluster. This includes a highly available etcd cluster, influxdb to store statistics and the Lighthouse service, which is
 the Web UI for Portworx.
 
-Portworx can be used to provision volumes on DCOS using either the Docker Volume Driver Interface (DVDI) or, directly 
+Portworx can be used to provision volumes on DCOS using either the Docker Volume Driver Interface (DVDI) or, directly
 through CSI.
 
 ## Deploy Portworx
@@ -39,8 +39,8 @@ If you want to modify the defaults, click on the “Install” button next to th
 “Advanced Installation”
 
 Through the advanced install options you can change the configuration of the Portworx deployment. Here you can choose to
-disable etcd (if you have an external etcd service) as well as disable the Lighthouse service in case you do not want to
-use the WebUI.
+disable etcd (if you have an external etcd service) If you wish to to have a custom etcd installation please refer this [doc](../maintain/etcd.md).
+You can also disable the Lighthouse service in case you do not want to use the WebUI.
 
 ### Portworx Options
 Specify your kvdb (consul or etcd) server if you don't want to use the etcd cluster with this service. If the etcd cluster
@@ -70,7 +70,7 @@ service.
 
 Once you have started the install you can go to the Services page to monitor the status of the installation.
 
-If you click on the Portworx service you should be able to look at the status of the services being created. 
+If you click on the Portworx service you should be able to look at the status of the services being created.
 
 In a default install there will be one service for the framework scheduler, 4 services for etcd (
 3 etcd nodes and one etcd proxy), one service for influxdb and one service for lighthouse.
@@ -87,7 +87,7 @@ link on the DCOS UI.
 
 Since Lighthouse is deployed on a private agent it might not be accessible from outside your network depending on your
 network configuration. To access Lighthouse from an external network you can deploy the
-[Repoxy](https://gist.github.com/nlsun/877411115f7e3b885b5e9daa8821722f) service to redirect traffic from one of the public 
+[Repoxy](https://gist.github.com/nlsun/877411115f7e3b885b5e9daa8821722f) service to redirect traffic from one of the public
 agents.
 
 To do so, run the following marathon application
@@ -144,8 +144,8 @@ The default username/password is portworx@yourcompany.com/admin
 
 ## Scaling Up Portworx Nodes
 
-If you add more agents to your DCOS cluster and you want to install Portworx on those new nodes, you can increase the 
-NODE_COUNT to start install on the new nodes. This will relaunch the service scheduler and install Portworx on the nodes 
+If you add more agents to your DCOS cluster and you want to install Portworx on those new nodes, you can increase the
+NODE_COUNT to start install on the new nodes. This will relaunch the service scheduler and install Portworx on the nodes
 which didn't have it previously.
 
 ![Scale up PX Nodes](/images/dcos-px-scale-up.png){:width="655px" height="200px"}

--- a/scheduler/mesosphere-dcos/install.md
+++ b/scheduler/mesosphere-dcos/install.md
@@ -39,7 +39,7 @@ If you want to modify the defaults, click on the “Install” button next to th
 “Advanced Installation”
 
 Through the advanced install options you can change the configuration of the Portworx deployment. Here you can choose to
-disable etcd (if you have an external etcd service) If you wish to to have a custom etcd installation please refer this [doc](../maintain/etcd.md).
+disable etcd (if you have an external etcd service) If you wish to to have a custom etcd installation please refer this [doc](/maintain/etcd.html).
 You can also disable the Lighthouse service in case you do not want to use the WebUI.
 
 ### Portworx Options


### PR DESCRIPTION
Replace all the instances where we recommend etcd installation to point to the new page for etcd installation.