### PR TITLE
Include Marketo analytics code in head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,3 +48,5 @@
 {% if page.meta-description %}
     <meta name="description" content="{{ page.meta-description }}"/>
 {% endif %}
+
+{% include marketo_analytics.html %}

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /getting-started/px-enterprise.html
   - /getting-started/px-developer.html
   - /hadoop.html
+  - /coming_soon.html	
 meta-description: "Find out more about Portworx, the persistent storage solution for containers. Come check us out for step-by-step guides and tips!"
 ---
 


### PR DESCRIPTION
After a little digging, it does appear the tracking snippet provided by Marketo does exist in the codebase, but is never included. I have included it in the header.

Untested and unable to test.