### PR TITLE
PWX-4306: Fix GKE docs

### DIFF
--- a/scheduler/kubernetes/gke.md
+++ b/scheduler/kubernetes/gke.md
@@ -62,126 +62,65 @@ master nodes. This controller communicates with Portworx running on minions usin
 are not accessible from the master nodes in GKE. Due to this the PV binder contoller can not communicate with Portworx
 running on the minions.
 
-To overcome this, we can run the PV binder controller as a pod on one of the minions. This controller would be in charge of
-listening for new PV claims and binding them. Since this controller would be running on one of the minions it will be able to
-communicate with Portworx using the Service and dynamically provision volumes.
+To overcome this, we need to run the PV binder controller as a pod on one of the minions. This controller is
+listening for new PV claims and binding them. Since this controller is running on one of the minions it is able to
+communicate with Portworx using the Service and 
+[dynamically provisioned volumes](/scheduler/kubernetes/dynamic-provisioning.html).
 
-## Starting PV binder controller
-The PV binder controller pod can be started by using the following spec:
+### Starting PV binder controller
+If you used the Web HTML form at [http://install.portworx.com](http://install.portworx.com) to build your YAML spec, please make sure to specify the exact Kubernetes server version (ie. `kbver=1.8.4-gke.0`).
+
+In this case, the generated YAML will contain all the necessary configuration (including the [PV binder controller](https://docs.portworx.com/scheduler/kubernetes/px-pvc-controller.yaml)), and you will not need to deploy the PV binder controller manually.
+
+#### Manual deployment of PV binder controller pod
+To deploy the PV binder controller pod manually, save [the PV binder spec](https://docs.portworx.com/scheduler/kubernetes/px-pvc-controller.yaml) to a file and then apply it using kubectl:
 
 ```
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: portworx-pvc-controller-account
-  namespace: kube-system
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-   name: portworx-pvc-controller-role
-rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: portworx-pvc-controller-role-binding
-subjects:
-- kind: ServiceAccount
-  name: portworx-pvc-controller-account
-  namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: portworx-pvc-controller-role
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
-  labels:
-    tier: control-plane
-  name: portworx-pvc-controller
-  namespace: kube-system
-spec:
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
-      labels:
-        name: portworx-pvc-controller
-        tier: control-plane
-    spec:
-      containers:
-      - command:
-        - kube-controller-manager
-        - --leader-elect=false
-        - --address=0.0.0.0
-        - --controllers=persistentvolume-binder
-        - --use-service-account-credentials=true
-        image: gcr.io/google_containers/kube-controller-manager-amd64:v1.7.8
-        livenessProbe:
-          failureThreshold: 8
-          httpGet:
-            host: 127.0.0.1
-            path: /healthz
-            port: 10252
-            scheme: HTTP
-          initialDelaySeconds: 15
-          timeoutSeconds: 15
-        name: portworx-pvc-controller-manager
-        resources:
-          requests:
-            cpu: 200m
-      hostNetwork: true
-      serviceAccountName: portworx-pvc-controller-account
+$ curl -o px-pvc-controller.yaml \
+    https://docs.portworx.com/scheduler/kubernetes/px-pvc-controller.yaml
+
+# Update the kubernetes versions in the spec (if required)
+$ vi px-pvc-controller.yaml
+
+$ kubectl apply -f px-pvc-controller.yaml
 ```
 
+Once the spec has been applied, please validate that the pod reached "Ready=1/1" state:
 
-To deploy the above pod, save the spec to a file and then apply it using kubectl:
-```
-curl -o px-pvc-controller.yaml https://docs.portworx.com/scheduler/kubernetes/px-pvc-controller.yaml
-# Update the kubernetes version in the image if required
-kubectl apply -f px-pvc-controller.yaml
-```
-
-Once the spec has been applied, wait for the pod to go to "Running" state:
 ```
 $ kubectl get pods -n kube-system
-...
-portworx-pvc-controller-2561368997-5s35p              1/1       Running   0          43s
-...
-```
-After the controller is in Running statue you can [use PV claims to dynamically provision Portworx volumes on GKE](/scheduler/kubernetes/dynamic-provisioning.html).
-
-### Notes
-* This spec is for Kubernetes v1.7.8. If you are using another version of Kubernetes please update the tag in the image
-to match that version. You can get the Kubernetes server version from the GKE console as well as by running `kubectl version`.
-
-* If you encounter an error with the cluster role permission (```clusterroles.rbac.authorization.k8s.io "portworx-pvc-controller-role" is forbidden```), create a clusterrolebinding for your user using the following commands:
-```
-# get current google identity
-$ gcloud info | grep Account
-Account: [myname@example.org]
-# grant cluster-admin to your current identity
-$ kubectl create clusterrolebinding myname-cluster-admin-binding --clusterrole=cluster-admin --user=myname@example.org
-Clusterrolebinding "myname-cluster-admin-binding" created
+NAME                                      READY     STATUS    RESTARTS   AGE
+portworx-pvc-controller-2561368997-5s35p  1/1       Running   0          43s
+[...]
 ```
 
->**Note:**<br/> GKE instances under certain scenarios do not automatically re-attach the persistent disks used by PX.
+## Troubleshooting Notes
 
-Under the following scenarios, GKE will spin up a new VM as a replacement for older VMs with the same node name. However the previously attached persistent disks are not re-attached.
-* When you halt a VM in GKE cluster
-* When you upgrade GKE between different kubernetes version.
-* Increasing the size of the node pool.
+* The `kubectl apply ...` command fails with "forbidden" error:
+   - If you encounter an error with the cluster role permission (```clusterroles.rbac.authorization.k8s.io "portworx-pvc-controller-role" is forbidden```), create a ClusterRoleBinding for your user using the following commands:
 
-Currently you will have to manually re-attach the persistent disk to the new VM and then restart portworx. If you face any issues with GKE reach out to us on [slack](http://slack.portworx.com)
+   ```
+   # get current google identity
+   $ gcloud info | grep Account
+   Account: [myname@example.org]
+
+   # grant cluster-admin to your current identity
+   $ kubectl create clusterrolebinding myname-cluster-admin-binding \
+      --clusterrole=cluster-admin --user=myname@example.org
+   Clusterrolebinding "myname-cluster-admin-binding" created
+   ```
+
+* The `kubectl apply ...` command fails with "error validating":
+   - this likely happened because of versions discrepancy between "kubectl" client and Kubernetes backend server (ie. using "kubectl" v1.8.4 to apply spec to Kubernetes server v1.6.13-gke.0)
+   - to fix this, you can either:
+      1. downgrade the "kubectl" version to match your server's version, or
+      2. reapply the spec with client-validation turned off,  e.g.:<br/>`kubectl apply --validate=false ...`
+
+* GKE instances under certain scenarios do not automatically re-attach the persistent disks used by PX.
+   - Under the following scenarios, GKE will spin up a new VM as a replacement for older VMs with the same node name. However the previously attached persistent disks are not re-attached:
+      1. When you halt a VM in GKE cluster
+      2. When you upgrade GKE between different kubernetes version.
+      3. Increasing the size of the node pool.
+   - Currently you will have to manually re-attach the persistent disk to the new VM and then restart portworx.
+
+If you face any issues with GKE, reach out to us on [slack](http://slack.portworx.com)

--- a/scheduler/kubernetes/px-pvc-controller.yaml
+++ b/scheduler/kubernetes/px-pvc-controller.yaml
@@ -1,3 +1,12 @@
+# The following YAML-spec installs portworx-pvc-controller, which is required
+# in GKE/OpenShift kubernetes environments to expose Portworx PVC-volumes to
+# nodes.
+#
+# If installing manually, you many need to adjust the
+# "apiVersion: rbac.authorization.k8s.io/<VERSION>" tag to match your cluster:
+# - kubernetes 1.6.x and 1.7.x use "<VERSION> = v1beta1" while
+# - kubernetes 1.8.x uses "<VERSION> = v1".
+#
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
* adding note about automatic PV binder YAML when using correct `kbver`-tag
* reducing "Manual deployment of PV binder" section
* cleaning up Troubleshooting section