### PR TITLE
Fixing Kubernetes upgrade pages

### DIFF
--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -137,6 +137,10 @@ $ curl -o px-spec.yaml \
   "http://install.portworx.com?c=mycluster&k=etcd://etcd.fake.net:2379&e=PX_HTTP_PROXY=<http-proxy>,PX_HTTPS_PROXY=<https-proxy>"
 ```
 
+## Upgrade
+
+For information about upgrading Portworx inside Kubernetes, please refer to the dedicated [upgrade page](/scheduler/kubernetes/upgrade.html).
+
 ## Uninstall
 
 Uninstalling or deleting the portworx daemonset only removes the portworx containers from the nodes. As the configurations files which PX use are persisted on the nodes the storage devices and the data volumes are still intact. These portworx volumes can be used again if the PX containers are started with the same configuration files.

--- a/scheduler/kubernetes/upgrade-legacy.md
+++ b/scheduler/kubernetes/upgrade-legacy.md
@@ -8,7 +8,7 @@ sidebar: home_sidebar
 * TOC
 {:toc}
 
->**IMPORTANT:**<br/> This method of upgrading portworx is DEPRECATED.  If you are running Portworx as PX-Container DaemonSet, we highly reccomend to migrate it into the OCI containers by following the [upgrade instructions](/scheduler/kubernetes/upgrade.html#migrating-px-container-to-px-oci-daemonset).
+>**IMPORTANT:**<br/> This method of upgrading portworx is DEPRECATED.  If you are running Portworx as PX-Container DaemonSet, we highly reccomend to migrate it into the OCI containers by following the [upgrade instructions](/scheduler/kubernetes/upgrade.html#migrating-from-legacy-portworx).
 
 This guide walks through upgrading Portworx deployed as a PX-Container DaemonSet in a Kubernetes cluster.  For instructions how to upgrade OCI containers DaemonSet, please follow the same [upgrade instructions](/scheduler/kubernetes/upgrade.html).
 

--- a/scheduler/kubernetes/upgrade-legacy.md
+++ b/scheduler/kubernetes/upgrade-legacy.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "Upgrade Portworx on Kubernetes (Deprecated)"
+keywords: portworx, container, Kubernetes, storage, Docker, k8s, flexvol, pv, persistent disk
+sidebar: home_sidebar
+---
+
+* TOC
+{:toc}
+
+>**IMPORTANT:**<br/> This method of upgrading portworx is DEPRECATED.  If you are running Portworx as PX-Container DaemonSet, we highly reccomend to migrate it into the OCI containers by following the [upgrade instructions](/scheduler/kubernetes/upgrade.html#migrating-px-container-to-px-oci-daemonset).
+
+This guide walks through upgrading Portworx deployed as a PX-Container DaemonSet in a Kubernetes cluster.  For instructions how to upgrade OCI containers DaemonSet, please follow the same [upgrade instructions](/scheduler/kubernetes/upgrade.html).
+
+In the current version, Portworx recommends following an update strategy of 'OnDelete'. With 'OnDelete' update strategy, after you update a DaemonSet template, new DaemonSet pods will only be created when you manually delete old DaemonSet pods. Doing so gives end users more control on when they are ready to upgrade Portworx on a particular node.
+
+Users are expected to migrate application pods using Portworx volumes to another node before deleting the old Portworx pod.
+
+Follow the below sequence to upgrade Portworx in your cluster.
+
+### 1. Ensure that the DaemonSet update strategy is "OnDelete"
+
+* Check current update strategy using command: `$ kubectl get ds portworx -n kube-system -o yaml | grep -A 3 updateStrategy:`
+* If the updateStrategy type is `RollingUpdate`, change it to the `OnDelete`
+    * Edit the spec using command: `$ kubectl edit ds portworx -n kube-system`
+    * This will open the spec in an editor. Change updateStrategy to `OnDelete` and save the file. This section in your spec should look like below:
+        ```yaml
+        updateStrategy:
+            type: OnDelete
+        ```
+
+### 2. Upgrade the Portworx spec
+
+* Change the image of the Portworx Daemonset
+    * Set the image with command: `$ kubectl set image ds portworx portworx=portworx/px-enterprise:1.2.10 -n kube-system`
+    * Alternately, you can also change the image in the DaemonSet spec file and apply it using `$ kubectl apply -f <px-spec.yaml>`.
+* Update the `ClusterRole` permissions in Portworx spec using below:
+
+    ```
+    cat <<EOF | kubectl apply -f -
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1alpha1
+    metadata:
+       name: node-get-put-list-role
+    rules:
+    - apiGroups: [""]
+      resources: ["nodes"]
+      verbs: ["get", "update", "list"]
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]
+    EOF
+    ```
+
+### 3. Upgrade Portworx pods
+
+It is not recommended to delete the Portworx pod while an application is actively issuing I/O. This can induce race conditions in docker causing it to hang. 
+
+The following procedure should be followed:
+1. Cordon the node where you want to upgrade Portworx: `$ kubectl cordon <node-name>`
+2. Delete application pods running on this node that are using Portworx volumes: `$ kubectl delete pod <pod-name>`
+    * Since application pods are expected to be managed by a controller like `Deployement` or `StatefulSet`, Kubernetes will spin up a new replacement pod on another node.
+3. Delete Portworx pod running on this node. This will start a new Portworx pod on this node with the new version you set above. (Note: Cordoning a kubernetes node doesn't affect DaemonSet pods)
+4. A new Portworx pod with the new version will be initiated on this node. This pod will stay in initializing state.
+5. Reboot the node. (This step is needed only if your current Portworx version is 1.2.9 since it requires a reboot of the host to perform upgrade of our kernel driver.)
+6. Uncordon the node once it comes up.

--- a/scheduler/kubernetes/upgrade.md
+++ b/scheduler/kubernetes/upgrade.md
@@ -116,7 +116,7 @@ minion2 192.168.56.71   3.316327        4.1 GB          3.2 GB          N/A     
 
 ## Migrating from Legacy Portworx
 
-The legacy Portworx installations (v1.2.10 and older) have been deploying as PX-Containers Kubernetes daemonsets (i.e. Portworx running directly as Docker container), but since then we have changed the deployments as via [OCI runC](/runc/runc/index.html), which eliminates cyclical dependancies, speeds up service restarts, and brings other improvements.
+The legacy Portworx installations (v1.2.10 and older) have been deploying as PX-Containers Kubernetes daemonsets (i.e. Portworx running directly as Docker container), but since then we have changed the deployments as via [OCI runC](/runc/index.html), which eliminates cyclical dependancies, speeds up service restarts, and brings other improvements.
 
 There are no special instructions required to migrate your old PX-Container into the latest OCI runC Daemonset - please follow the instructions listed [above](#upgrading-portworx) to generate a new YAML spec-file, reapply it on your Kubernetes cluster, and this will automatically migrate Portworx to OCI containers deployment.
 

--- a/scheduler/kubernetes/upgrade.md
+++ b/scheduler/kubernetes/upgrade.md
@@ -21,7 +21,7 @@ The Portworx Daemonset is using `RollingUpdate` update strategy, which greatly s
 
 ### Step 1) Apply updated YAML-spec
 
-The upgrade Portworx, we will just have to re-apply the YAML spec-file generated from the [install.portworx.com](http://install.portworx.com) site, which is very similar to how we [installed Portworx](/scheduler/kubernetes/install.html#install).
+To upgrade Portworx, we will just have to re-apply the YAML spec-file generated from the [install.portworx.com](http://install.portworx.com) site, which is very similar to how we [installed Portworx](/scheduler/kubernetes/install.html#install).
 
 
 **OPTION a)**:<br/>

--- a/scheduler/kubernetes/upgrade.md
+++ b/scheduler/kubernetes/upgrade.md
@@ -8,57 +8,115 @@ sidebar: home_sidebar
 * TOC
 {:toc}
 
-This guide walks through upgrading Portworx deployed as a DaemonSet in a Kubernetes cluster.
+This guide describes the procedure how to upgrade Portworx in Kubernetes environment as OCI container, which is the default and recommended method of running Portworx in Kubernetes.
 
-In the current version, Portworx recommends following an update strategy of 'OnDelete'. With 'OnDelete' update strategy, after you update a DaemonSet template, new DaemonSet pods will only be created when you manually delete old DaemonSet pods. Doing so gives end users more control on when they are ready to upgrade Portworx on a particular node.
+We assume you have deployed Portworx as [Kubernetes Daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) using instructions provided at our [install page](/scheduler/kubernetes/install.html).
 
-Users are expected to migrate application pods using Portworx volumes to another node before deleting the old Portworx pod.
 
-Follow the below sequence to upgrade Portworx in your cluster.
+>**IMPORTANT:**<br/>We do not recommend upgrading Portworx using [Kubernetes instructions](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/) (e.g. via `kubectl set image ds/portworx portworx=portworx/XXXX:### -n kube-system`).<br/>
+>Instead, whenever possible, we recommend using the [install.portworx.com](http://install.portworx.com) site to generate latest recommended YAML-spec, and re-apply the spec to upgrade Portworx.
 
-### 1. Ensure that the DaemonSet update strategy is "OnDelete"
 
-* Check current update strategy using command: `$ kubectl get ds portworx -n kube-system -o yaml | grep -A 3 updateStrategy:`
-* If the updateStrategy type is `RollingUpdate`, change it to the `OnDelete`
-    * Edit the spec using command: `$ kubectl edit ds portworx -n kube-system`
-    * This will open the spec in an editor. Change updateStrategy to `OnDelete` and save the file. This section in your spec should look like below:
-        ```yaml
-        updateStrategy:
-            type: OnDelete
-        ```
+>**NOTE**: This procedure will also automatically migrate all legacy PX-Container deployments into the OCI containers.  If you are looking for legacy instructions how to upgrade PX-Container deployments, you can find them [here](/scheduler/kubernetes/upgrade-legacy.html).
 
-### 2. Upgrade the Portworx spec
 
-* Change the image of the Portworx Daemonset
-    * Set the image with command: `$ kubectl set image ds portworx portworx=portworx/px-enterprise:1.2.10 -n kube-system`
-    * Alternately, you can also change the image in the DaemonSet spec file and apply it using `$ kubectl apply -f <px-spec.yaml>`.
-* Update the `ClusterRole` permissions in Portworx spec using below:
+## Upgrading PX-OCI
 
-    ```
-    cat <<EOF | kubectl apply -f -
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1alpha1
-    metadata:
-       name: node-get-put-list-role
-    rules:
-    - apiGroups: [""]
-      resources: ["nodes"]
-      verbs: ["get", "update", "list"]
-    - apiGroups: [""]
-      resources: ["pods"]
-      verbs: ["get", "list"]
-    EOF
-    ```
+The PX-OCI Daemonset is using `RollingUpdate` update strategy, which greatly simplifies the upgrade process.
 
-### 3. Upgrade Portworx pods
+### Step 1) Apply updated YAML-spec
 
-It is not recommended to delete the Portworx pod while an application is actively issuing I/O. This can induce race conditions in docker causing it to hang. 
+The upgrade the PX-OCI, we will just have to re-apply the YAML spec-file generated from the [install.portworx.com](http://install.portworx.com) site.  The same applies if we want to migrate from the deprecated PX-Container to the recommended PX-OCI daemonset.
 
-The following procedure should be followed:
-1. Cordon the node where you want to upgrade Portworx: `$ kubectl cordon <node-name>`
-2. Delete application pods running on this node that are using Portworx volumes: `$ kubectl delete pod <pod-name>`
-    * Since application pods are expected to be managed by a controller like `Deployement` or `StatefulSet`, Kubernetes will spin up a new replacement pod on another node.
-3. Delete Portworx pod running on this node. This will start a new Portworx pod on this node with the new version you set above. (Note: Cordoning a kubernetes node doesn't affect DaemonSet pods)
-4. A new Portworx pod with the new version will be initiated on this node. This pod will stay in initializing state.
-5. Reboot the node. (This step is needed only if your current Portworx version is 1.2.9 since it requires a reboot of the host to perform upgrade of our kernel driver.)
-6. Uncordon the node once it comes up.
+
+**OPTION a)**:<br/>
+If you have the original URL that you used to generate your first YAML-spec, you can just download and reapply the updated YAML-spec from the same URL, e.g.:<br/>`kubectl apply -f '<original http://install.portworx.com/... url>'`.
+
+
+
+**OPTION b)**:<br/>
+If you did not preserve the original installation URL, not to worry, in most cases the configuration is very easy to reconstruct using your current Kubernetes configuration, like so:
+
+```
+$ kubectl get ds/portworx -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[*].args}'
+
+[-k etcd:http://etcd1.acme.net:2379,etcd:http://etcd2.acme.net:2379 \
+ -c cluster123 -s /dev/sdb1 -s /dev/sdc -x kubernetes]
+```
+* you can ignore the '-x kubernetes' parameter (will be applied by default), also
+* if you were using separate devices, you will need to collapse multiple "-s dev1 -s dev2 ..." into a single parameter "s=dev1,dev2"
+
+You can re-enter the parameters on the YAML web-form at [install.portworx.com](http://install.portworx.com), or convert them manually.
+The final YAML-spec from our example above would look similar to this:
+
+```bash
+VER=$(kubectl version --short | awk -Fv '/Server Version: /{print $3}')
+curl -o oci-spec.yaml \
+   'http://install.portworx.com?c=cluster123&k=etcd:http://etcd1.acme.net:2379,etcd:http://etcd2.acme.net:2379&s=/dev/sdb1,/dev/sdc&kbver=$VER'
+kubectl apply -f oci-spec.yaml
+```
+
+
+
+Once you have applied the new YAML-spec, Kubernetes will start applying the Portworx upgrade in a "RollingUpdate" fashion, one node at a time.
+
+
+### Step 2) Monitor the rolling upgrade
+
+<U>ROLLOUT STATUS</U>:<br/>
+One can monitor the upgrade process by running the "kubectl rollout status" command:
+
+```
+$ kubectl rollout status ds/portworx -n kube-system
+Waiting for rollout to finish: 0 out of 4 new pods have been updated...
+Waiting for rollout to finish: 1 out of 4 new pods have been updated...
+Waiting for rollout to finish: 2 out of 4 new pods have been updated...
+Waiting for rollout to finish: 3 out of 4 new pods have been updated...
+Waiting for rollout to finish: 3 of 4 updated pods are available...
+daemon set "portworx" successfully rolled out
+```
+
+Note that this command will inform us of general upgrade progress, but it will not point on which exact node is being upgraded and when.
+
+<U>NODES PORTWORX PODS STATUS</U>:<br/>
+To get more information about the status of Portworx daemonset across the nodes, we can run the following command:
+
+```
+$ kubectl get pods -o wide -n kube-system -l name=portworx
+NAME             READY     STATUS              RESTARTS   AGE       IP              NODE
+portworx-9njsl   1/1       Running             0          16d       192.168.56.73   minion4
+portworx-fxjgw   1/1       Running             0          16d       192.168.56.74   minion5
+portworx-fz2wf   1/1       Running             0          5m        192.168.56.72   minion3
+portworx-x29h9   0/1       ContainerCreating   0          0s        192.168.56.71   minion2
+```
+
+As we can see in the example output above:
+
+* looking at the STATUS/READY, we can tell that the rollout-upgrade is currently creating the container on the "minion2" node
+* looking at AGE, we can tell that
+	* "minion4" and "minion5" have Portworx up for 16 days (likely still on old version, and to be upgraded), while the
+	* "minion3" has Portworx up for only 5 minutes (likely just upgraded and restarted)
+* if we keep on monitoring, we will observe that the upgrade will not switch to the "next" node until STATUS is "Running" and the READY is 1/1 (meaning, the "readynessProbe" reports Portworx service is fully up).
+
+<U>PORTWORX CLUSTER LIST</U>:<br/>
+Finally, one can also run the following command to inspect the Portworx cluster:
+
+```
+minion1$ /opt/pwx/bin/pxctl cluster list
+[...]
+Nodes in the cluster:
+ID      DATA IP         CPU             MEM TOTAL       MEM FREE        CONTAINERS      VERSION                 STATUS
+minion5 192.168.56.74   1.530612        4.0 GB          3.1 GB          N/A             1.2.11.4-3598f81        Online
+minion4 192.168.56.73   3.836317        4.0 GB          3.0 GB          N/A             1.2.11.4-3598f81        Online
+minion3 192.168.56.72   3.324808        4.1 GB          3.3 GB          N/A             1.2.11.9-8aa25b7        Online
+minion2 192.168.56.71   3.316327        4.1 GB          3.2 GB          N/A             1.2.11.9-8aa25b7        Online
+```
+* from the output above, we can confirm that the
+	* "minion4" and "minion5" are still on the old Portworx version (1.2.11.4), while
+	* "minion3" and "minion2" have already been upgraded to the latest version (in our case, v1.2.11.9).
+
+
+## Migrating PX-Container to PX-OCI daemonset
+
+There are no special instructions required to migrate your old PX-Container into the latest PX-OCI Daemonset - please follow the instructions listed at [Upgrading PX-OCI](#upgrading-px-oci) to generate a new YAML spec-file using [install.portworx.com](http://install.portworx.com).


### PR DESCRIPTION
* moved original PX-Container's instructions into `upgrade-legacy.md`
* adding PX-OCI instructions only into `upgrade.md`
* modified install.md to include a pointer to Upgrade page