### PR TITLE
Improve px k8s install workflow

### DIFF
--- a/knowledgebase/shared-mount-propogation.md
+++ b/knowledgebase/shared-mount-propogation.md
@@ -54,7 +54,7 @@ $ sudo systemctl restart docker
 
 ### RedHat/CentOS Configuration and Shared Mounts
 
-1. Follow the Docker installation guide, [Red Hat Enterprise Linux](https://docs.docker.com/engine/installation/linux/rhel/) and then start the Docker service.
+1. Follow the Docker installation guide for [Red Hat Enterprise Linux](https://www.docker.com/docker-red-hat-enterprise-linux-rhel)/[Centos](https://docs.docker.com/engine/installation/linux/centos/) and then start the Docker service.
 
 2. Verify that your Docker version is 1.10 or later:
 ```
@@ -79,7 +79,7 @@ $ sudo systemctl restart docker
 ### Ubuntu Configuration and Shared Mounts
 
 1. SSH into your first server.
-2. Follow the Docker installation guide for [Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntulinux/):
+2. Follow the Docker installation guide for [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/):
 
 3. Verify that your Docker version is 1.10 or later. In your SSH window, run:
 ```

--- a/reference-architecture/docker-datacenter.md
+++ b/reference-architecture/docker-datacenter.md
@@ -31,16 +31,16 @@ The recommended deployent of Portworx with DDC is bare-metal Linux or Azure.
 ## Step 1: Obtain DDC License
 
 Running Docker UCP will require a license from Docker for use past the 30-day trial period.
-Visit the [Docker Store](https://store.docker.com/bundles/docker-datacenter/purchase?plan=free-trial) to obtain a [DDC license](https://docs.docker.com/ucp/installation/license).
+Visit the [Docker Store](https://store.docker.com/bundles/docker-datacenter/purchase?plan=free-trial) to obtain a DDC license.
 
 ## Step 2: Install Docker CSE on Nodes
 
 DDC requires that the Docker CSE to be installed.
-Follow instructions to install [Docker CSE](https://docs.docker.com/cs-engine/install/)
+Follow instructions to install [Docker CSE](https://docs.docker.com/cs-engine/1.13/)
 
 ## Step 3:  Install Docker UCP
 
-Follow the instructions for [Installing Docker UCP](https://docs.docker.com/ucp/installation/install-production).
+Follow the instructions for [Installing Docker UCP](https://docs.docker.com/datacenter/ucp/2.2/guides/).
 
 ## Step 3a: (Optional) Update your docker.service file
 

--- a/scheduler/docker/ucp.md
+++ b/scheduler/docker/ucp.md
@@ -11,13 +11,11 @@ redirect_from: "/run-with-docker-ucp.html"
 
 You can use Portworx to implement storage for Docker Universal Control Plane (UCP). This section is qualified using Docker 1.11 and Universal Control Plane 1.1.2.
 
-## Step 1: Install and license Docker UCP
+## Step 1: Install Docker UCP
 
-Follow the instructions for [Installing Docker UCP](https://docs.docker.com/ucp/installation/install-production).
+Follow the instructions for [Installing Docker UCP](https://docs.docker.com/datacenter/ucp/2.2/guides/).
 
 >**Note:**<br/>You must run Docker Commercially Supported (CS) Engine.
-
-After installing Docker UCP, you must [license your installation](https://docs.docker.com/ucp/installation/license).
 
 ## Step 2: Update your docker.service file
 

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -55,7 +55,11 @@ Portworx gets deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/co
 
 #### Generating the spec
 
-To generate the spec file, head on to [http://install.portworx.com](http://install.portworx.com) and fill in the parameters.
+To generate the spec file, head on to [http://install.portworx.com](http://install.portworx.com) and fill in the parameters. When filing the `kbver` (Kubernetes version) on the page, use output of: 
+
+```bash
+kubectl version --short | awk -Fv '/Server Version: /{print $3}'
+```
 
 Alternately, you can use `curl` to generate the spec as described in [Generating Portworx Kubernetes spec using curl](/scheduler/kubernetes/px-k8s-spec-curl.html).
 

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -51,59 +51,36 @@ The native portworx driver in Kubernetes supports the following features:
 
 If you are installing on [Openshift](https://www.openshift.com/), follow [these instructions](/scheduler/kubernetes/openshift-install.html).
 
-PX can be deployed with a single command as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) with the following:
+Portworx gets deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). Following sections describe how to generate the spec files and apply them.
+
+#### Generating the spec
+
+To generate the spec file, head on to [http://install.portworx.com](http://install.portworx.com) and fill in the parameters.
+
+Alternately, you can use `curl` to generate the spec as described in [Generating Portworx Kubernetes spec using curl](/scheduler/kubernetes/px-k8s-spec-curl.html).
+
+>**Secure ETCD:**<br/> If using secure etcd provide "https" in the URL and make sure all the certificates are in the `/etc/pwx/` directory on each host which is bind mounted inside PX container.
+
+#### Applying the spec
+
+Once you have generated the spec file, deploy Portworx.
 
 ```bash
-# Download the spec - substitute your parameters below
-VER=$(kubectl version --short | awk -Fv '/Server Version: /{print $3}')
-curl -o px-spec.yaml "http://install.portworx.com?c=mycluster&k=etcd://etc.company.net:2379&kbver=$VER"
-
-# Apply the spec
-kubectl apply -f px-spec.yaml
-
-# Monitor the deployment
-kubectl get pods -o wide -n kube-system -l name=portworx
-
-# Monitor Portworx cluster status
-PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='{.items[0].metadata.name}')
-
-kubectl exec $PX_POD -n kube-system -- /opt/pwx/bin/pxctl status
+$ kubectl apply -f px-spec.yaml
 ```
 
->**IMPORTANT:**<br/> To simplify the installation and entering the parameters, please head on to [http://install.portworx.com](http://install.portworx.com) and use the prepared HTML form.
+You can monitor the status using following commands.
+```
+# Monitor the portworx pods
 
->**Openshift Users:**<br/> Make sure you use `osft=true` when generating the spec.
-
-Below are all parameters that can be given in the query string  (see [install.portworx.com](http://install.portworx.com)).
-
-| Value  | Description                                                                                                                           | Example                                                    |
-|:-------|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
-|        | <center>REQUIRED PARAMETERS</center>                                                                                                  |                                                            |
-| c      | Specifies the unique name for the Portworx cluster.                                                                                   | <var>c=test_cluster</var>                                  |
-| k      | Your key value database, such as an etcd cluster or a consul cluster.                                                                 | <var>k=etcd:http://etcd.fake.net:2379</var>                |
-|        | <center>OPTIONAL PARAMETERS</center>                                                                                                  |                                                            |
-| s      | Specify comma-separated list of drives.                                                                                               | <var>s=/dev/sdb,/dev/sdc</var>                             |
-| d      | Specify data network interface. This is useful if your instances have non-standard network interfaces.                                | <var>d=eth1</var>                                          |
-| m      | Specify management network interface. This is useful if your instances have non-standard network interfaces.                          | <var>m=eth1</var>                                          |
-| kbver  | Specify Kubernetes version (current default is 1.7)                                                                                   | <var>kbver=1.8.4</var>                                     |
-| coreos | REQUIRED if target nodes are running coreos.                                                                                          | <var>coreos=true</var>                                     |
-| osft | REQUIRED if installing on Openshift.                                                                                          | <var> osft =true</var>                                     |
-| mas    | Specify if PX should run on the Kubernetes master node. For Kubernetes 1.6.4 and prior, this needs to be true (default is false)      | <var>mas=true</var>                                        |
-| z      | Instructs PX to run in zero storage mode on Kubernetes master.                                                                        | <var>z=true</var>                                          |
-| f      | Instructs PX to use any available, unused and unmounted drives or partitions. PX will never use a drive or partition that is mounted. | <var>f=true</var>                                          |
-| st     | Select the secrets type (_aws_, _kvdb_ or _vault_)                                                                                    | <var>st=vault</var>                                        |
-|        | <center>KVDB CONFIGURATION PARAMETERS</center>                                                                                        |                                                            |
-| pwd    | Username and password for ETCD authentication in the form user:password                                                               | <var>pwd=username:password</var>                           |
-| ca     | Location of CA file for ETCD authentication.                                                                                          | <var>ca=/path/to/server.ca</var>                           |
-| cert   | Location of certificate for ETCD authentication.                                                                                      | <var>cert=/path/to/server.crt</var>                        |
-| key    | Location of certificate key for ETCD authentication.                                                                                  | <var>key=/path/to/server.key</var>                         |
-| acl    | ACL token value used for Consul authentication.                                                                                       | <var>acl=398073a8-5091-4d9c-871a-bbbeb030d1f6</var>        |
-|        | <center>LIGHTHOUSE CONFIGURATION PARAMETERS</center>                                                                                  |                                                            |
-| t      | Portworx Lighthouse token for cluster.                                                                                                | <var>t=token-a980f3a8-5091-4d9c-871a-cbbeb030d1e6</var>    |
-| e      | Comma-separated list of environment variables that will be exported to portworx.                                                      | <var>e=API_SERVER=http://lighthouse-new.portworx.com</var> |
+$ kubectl get pods -o wide -n kube-system -l name=portworx
 
 
->**Note:**<br/> If using secure etcd provide "https" in the URL and make sure all the certificates are in a directory which is bind mounted inside PX container. (ex.: /etc/pwx)
+# Monitor Portworx cluster status
+
+$ PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='{.items[0].metadata.name}')
+$ kubectl exec $PX_POD -n kube-system -- /opt/pwx/bin/pxctl status
+```
 
 If you are still experiencing issues, please refer to [Troubleshooting PX on Kubernetes](support.html) and [General FAQs](/knowledgebase/faqs.html).
 
@@ -143,6 +120,26 @@ To view a list of all Portworx environment variables, go to [passing environment
 
 For information about upgrading Portworx inside Kubernetes, please refer to the dedicated [upgrade page](/scheduler/kubernetes/upgrade.html).
 
+## Service control 
+
+One can control the Portworx systemd service using the Kubernetes labels:
+
+* stop / start / restart the PX-OCI service
+  * note: this is the equivalent of running `systemctl stop portworx`, `systemctl start portworx` ... on the node
+
+  ```bash
+  kubectl label nodes minion2 px/service=start
+  kubectl label nodes minion5 px/service=stop
+  kubectl label nodes --all px/service=restart
+  ```
+
+* enable / disable the PX-OCI service
+  * note: this is the equivalent of running `systemctl enable portworx`, `systemctl disable portworx` on the node
+
+  ```bash
+  kubectl label nodes minion2 minion5 px/service=enable
+  ```
+
 ## Uninstall
 
 Uninstalling or deleting the portworx daemonset only removes the portworx containers from the nodes. As the configurations files which PX use are persisted on the nodes the storage devices and the data volumes are still intact. These portworx volumes can be used again if the PX containers are started with the same configuration files.
@@ -177,27 +174,6 @@ kubectl label nodes --all px/enabled-
 ```
 
 >**Note:**<br/>During uninstall, the Portworx configuration files under `/etc/pwx/` directory are preserved, and will not be deleted.
-
-## Service control 
-
-One can control the Portworx systemd service using the Kubernetes labels:
-
-* stop / start / restart the PX-OCI service
-  * note: this is the equivalent of running `systemctl stop portworx`, `systemctl start portworx` ... on the node
-
-  ```bash
-  kubectl label nodes minion2 px/service=start
-  kubectl label nodes minion5 px/service=stop
-  kubectl label nodes --all px/service=restart
-  ```
-
-* enable / disable the PX-OCI service
-  * note: this is the equivalent of running `systemctl enable portworx`, `systemctl disable portworx` on the node
-
-  ```bash
-  kubectl label nodes minion2 minion5 px/service=enable
-  ```
-
 
 ## Delete PX Cluster configuration
 The commands used in this section are DISRUPTIVE and will lead to loss of all your data volumes. Proceed with CAUTION.

--- a/scheduler/kubernetes/px-k8s-spec-curl.md
+++ b/scheduler/kubernetes/px-k8s-spec-curl.md
@@ -2,8 +2,6 @@
 layout: page
 title: "Generating Portworx Kubernetes spec using curl"
 keywords: portworx, container, Kubernetes, storage, Docker, k8s, flexvol, pv, persistent disk
-sidebar: home_sidebar
-
 meta-description: "Find out how to generate the Portworx Kubernetes spec using curl."
 ---
 

--- a/scheduler/kubernetes/px-k8s-spec-curl.md
+++ b/scheduler/kubernetes/px-k8s-spec-curl.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: "Generating Portworx Kubernetes spec using curl"
+keywords: portworx, container, Kubernetes, storage, Docker, k8s, flexvol, pv, persistent disk
+sidebar: home_sidebar
+
+meta-description: "Find out how to generate the Portworx Kubernetes spec using curl."
+---
+
+* TOC
+{:toc}
+
+## Generating the Portworx spec using curl
+
+Below is an example of using curl to generate the Portworx spec file. Review the [query parameters table](/scheduler/kubernetes/px-k8s-spec-curl.html#px-k8s-query-params) below and add parameters as needed.
+
+>**Openshift Users:**<br/> Make sure you use `osft=true` when generating the spec.
+
+```bash
+$ VER=$(kubectl version --short | awk -Fv '/Server Version: /{print $3}')
+$ curl -o px-spec.yaml "http://install.portworx.com?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
+```
+
+Below are all parameters that can be given in the query string.
+<a name="px-k8s-query-params"></a>
+
+| Value  | Description                                                                                                                           | Example                                                    |
+|:-------|:--------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
+|        | <center>REQUIRED PARAMETERS</center>                                                                                                  |                                                            |
+| c      | Specifies the unique name for the Portworx cluster.                                                                                   | <var>c=test_cluster</var>                                  |
+| k      | Your key value database, such as an etcd cluster or a consul cluster.                                                                 | <var>k=etcd:http://etcd.fake.net:2379</var>                |
+|        | <center>OPTIONAL PARAMETERS</center>                                                                                                  |                                                            |
+| s      | Specify comma-separated list of drives.                                                                                               | <var>s=/dev/sdb,/dev/sdc</var>                             |
+| d      | Specify data network interface. This is useful if your instances have non-standard network interfaces.                                | <var>d=eth1</var>                                          |
+| m      | Specify management network interface. This is useful if your instances have non-standard network interfaces.                          | <var>m=eth1</var>                                          |
+| kbver  | Specify Kubernetes version (current default is 1.7)                                                                                   | <var>kbver=1.8.4</var>                                     |
+| coreos | REQUIRED if target nodes are running coreos.                                                                                          | <var>coreos=true</var>                                     |
+| osft | REQUIRED if installing on Openshift.                                                                                          | <var> osft =true</var>                                     |
+| mas    | Specify if PX should run on the Kubernetes master node. For Kubernetes 1.6.4 and prior, this needs to be true (default is false)      | <var>mas=true</var>                                        |
+| z      | Instructs PX to run in zero storage mode on Kubernetes master.                                                                        | <var>z=true</var>                                          |
+| f      | Instructs PX to use any available, unused and unmounted drives or partitions. PX will never use a drive or partition that is mounted. | <var>f=true</var>                                          |
+| st     | Select the secrets type (_aws_, _kvdb_ or _vault_)                                                                                    | <var>st=vault</var>                                        |
+|        | <center>KVDB CONFIGURATION PARAMETERS</center>                                                                                        |                                                            |
+| pwd    | Username and password for ETCD authentication in the form user:password                                                               | <var>pwd=username:password</var>                           |
+| ca     | Location of CA file for ETCD authentication.                                                                                          | <var>ca=/path/to/server.ca</var>                           |
+| cert   | Location of certificate for ETCD authentication.                                                                                      | <var>cert=/path/to/server.crt</var>                        |
+| key    | Location of certificate key for ETCD authentication.                                                                                  | <var>key=/path/to/server.key</var>                         |
+| acl    | ACL token value used for Consul authentication.                                                                                       | <var>acl=398073a8-5091-4d9c-871a-bbbeb030d1f6</var>        |
+|        | <center>LIGHTHOUSE CONFIGURATION PARAMETERS</center>                                                                                  |                                                            |
+| t      | Portworx Lighthouse token for cluster.                                                                                                | <var>t=token-a980f3a8-5091-4d9c-871a-cbbeb030d1e6</var>    |
+| e      | Comma-separated list of environment variables that will be exported to portworx.                                                      | <var>e=API_SERVER=http://lighthouse-new.portworx.com</var> |
+
+
+>**Note:**<br/> If using secure etcd provide "https" in the URL and make sure all the certificates are in the `/etc/pwx/` directory on each host which is bind mounted inside PX container.


### PR DESCRIPTION
The main goal is to have a easy flow in the primary install page

1. Split the install section into multiple sections
2. Moved install using curl to it's own page and referenced it in the install section
3. Re-order service control and uninstlal
4. Make it explicit for people to supply paramters when generating the sepc

Screenshots attached

![screen shot 2017-12-20 at 1 55 12 pm](https://user-images.githubusercontent.com/26801153/34230632-909149ec-e58d-11e7-9c94-798bfed76173.png)
![screen shot 2017-12-20 at 1 56 52 pm](https://user-images.githubusercontent.com/26801153/34230666-ab3030a6-e58d-11e7-8d5f-767c90b02107.png)
