### PR TITLE
Embed katacoda interactive k8s tutorial

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -26,6 +26,8 @@
         url: /scheduler/kubernetes/install.html
       - title: Upgrade
         url: /scheduler/kubernetes/upgrade.html
+      - title: Interactive tutorials
+        url: /scheduler/kubernetes/install.html#interactive-tutorials
       - title: Stateful applications
         folderitems:
         - title: Cassandra

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -32,6 +32,7 @@ The native portworx driver in Kubernetes supports the following features:
 3. Persistent Volume Claims
 4. Persistent Volumes
 
+<a name="interactive-tutorials"></a>
 ## Interactive Tutorial
 
 Below tutorial gives a high level overview on installing Portworx on Kubernetes.

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -16,14 +16,13 @@ redirect_from:
 meta-description: "Find out how to install PX within a Kubernetes cluster and have PX provide highly available volumes to any application deployed via Kubernetes."
 ---
 
+![k8s porx Logo](/images/k8s-porx.png){:height="188px" width="188px"}
+
 * TOC
 {:toc}
 
 Portworx can run alongside Kubernetes and provide Persistent Volumes to other applications running on Kubernetes. This section describes how to deploy PX within a Kubernetes cluster and have PX provide highly available volumes to any application deployed via Kubernetes.
 
-![k8s porx Logo](/images/k8s-porx.png){:height="188px" width="188px"}
-
-## Deploy PX with Kubernetes
 Since Kubernetes [v1.6 release](https://github.com/kubernetes/kubernetes/releases/tag/v1.6.0), Kubernetes includes the Portworx native driver support which allows Dynamic Volume Provisioning.
 
 The native portworx driver in Kubernetes supports the following features:
@@ -32,6 +31,16 @@ The native portworx driver in Kubernetes supports the following features:
 2. Storage Classes
 3. Persistent Volume Claims
 4. Persistent Volumes
+
+## Interactive Tutorial
+
+Below tutorial gives a high level overview on installing Portworx on Kubernetes.
+
+<script src="//katacoda.com/embed.js"></script>
+<div id="deploy-px-k8s"
+    data-katacoda-id="portworx/deploy-px-k8s"
+    data-katacoda-color="004d7f"
+    style="height: 600px; padding-top: 20px;"></div>
 
 <a name="prereqs-section"></a>
 ## Prerequisites


### PR DESCRIPTION
This PR embeds our katacoda install tutorial on our k8s install page.

This idea is: before people starting reading our actual install doc, give them a sense of confidence on the overall workflow. This will reduce apprehension when reading our docs.

Screenshots attached on how the page will look.

<img width="949" alt="screen shot 2018-01-03 at 11 44 06 pm" src="https://user-images.githubusercontent.com/26801153/34554160-60804cfe-f0e0-11e7-9ad3-5a1c976af8cc.png">

<img width="1008" alt="screen shot 2018-01-03 at 11 44 17 pm" src="https://user-images.githubusercontent.com/26801153/34554159-6061bf3c-f0e0-11e7-8648-84d1b9ff2b2b.png">
