### PR TITLE
Moving selinux note section to docker plugin page

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -288,8 +288,6 @@
       url: /knowledgebase/sdn.html
     - title: Shared Mount Propogation
       url: /knowledgebase/shared-mount-propogation.html
-    - title: SELinux
-      url: /knowledgebase/selinux.html
     - title: Devicemapper Thinpool setup
       url: /knowledgebase/devicemapper.html
     - title: Docker User Namespaces

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -297,3 +297,6 @@ installation](#install-px-plugin) (ie. command `docker plugin inspect pxd` shoul
 
 * Q: Docker startup is slow, logs show Docker is trying to access `/run/docker/plugins/pxd.sock` file.
 	* A: The `/run/docker/plugins/pxd.sock` file should have been removed when the PX-Container services have been stopped.  If by any chance this file still exists on the host, please remove it manually.
+
+* Q: Are you getting a No such file or directory message when you use SELinux?
+	* A1: Portworx has a solution to resolve the issue [SELinux](#install-px-plugin) (ie. command `docker plugin inspect pxd` should work).  Reinstall plugin otherwise.

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -299,4 +299,4 @@ installation](#install-px-plugin) (ie. command `docker plugin inspect pxd` shoul
 	* A: The `/run/docker/plugins/pxd.sock` file should have been removed when the PX-Container services have been stopped.  If by any chance this file still exists on the host, please remove it manually.
 
 * Q: Are you getting a No such file or directory message when you use SELinux?
-	* A1: Portworx has a solution to resolve the issue [SELinux](#install-px-plugin) (ie. command `docker plugin inspect pxd` should work).  Reinstall plugin otherwise.
+	* A1: Portworx has a solution to resolve the issue [SELinux](#/knowledgebase/selinux.html).


### PR DESCRIPTION
Removed selinux from home_sidebar.yml and added to the docker plugin trouble section.