### PR TITLE
Moving selinux note section to docker plugin page

### DIFF
--- a/knowledgebase/selinux.md
+++ b/knowledgebase/selinux.md
@@ -2,6 +2,7 @@
 layout: page
 title: "PX with SELinux"
 keywords: portworx, troubleshooting, logs, issue
+sidebar: home_sidebar
 redirect_from: "/scheduler/docker/docker-plugin.html"
 meta-description: "Are you getting a No such file or directory message when you use SELinux? Portworx has a solution to resolve the issue."
 ---

--- a/knowledgebase/selinux.md
+++ b/knowledgebase/selinux.md
@@ -2,8 +2,7 @@
 layout: page
 title: "PX with SELinux"
 keywords: portworx, troubleshooting, logs, issue
-sidebar: home_sidebar
-redirect_from: "/selinux.html"
+redirect_from: "/scheduler/docker/docker-plugin.html"
 meta-description: "Are you getting a No such file or directory message when you use SELinux? Portworx has a solution to resolve the issue."
 ---
 

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -299,4 +299,4 @@ installation](#install-px-plugin) (ie. command `docker plugin inspect pxd` shoul
 	* A: The `/run/docker/plugins/pxd.sock` file should have been removed when the PX-Container services have been stopped.  If by any chance this file still exists on the host, please remove it manually.
 
 * Q: Are you getting a No such file or directory message when you use SELinux?
-	* A1: Portworx has a solution to resolve the issue [SELinux](#/knowledgebase/selinux.html).
+	* A1: Portworx has a solution to resolve the issue [SELinux](#/knowledgebase/selinux.md).

--- a/scheduler/docker/docker-plugin.md
+++ b/scheduler/docker/docker-plugin.md
@@ -299,4 +299,4 @@ installation](#install-px-plugin) (ie. command `docker plugin inspect pxd` shoul
 	* A: The `/run/docker/plugins/pxd.sock` file should have been removed when the PX-Container services have been stopped.  If by any chance this file still exists on the host, please remove it manually.
 
 * Q: Are you getting a No such file or directory message when you use SELinux?
-	* A1: Portworx has a solution to resolve the issue [SELinux](#/knowledgebase/selinux.md).
+	* A1: Portworx has a solution to resolve the issue [SELinux](/knowledgebase/selinux.html).


### PR DESCRIPTION
Removed selinux section from home_sidebar.html and moved to the docker-plugin page.