### PR TITLE
Add/Link Ops guide to main Mesosphere section

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -90,6 +90,8 @@
           url: /scheduler/mesosphere-dcos/zookeeper.html
       - title: How To
         folderitems:
+        - title: Running Portworx in Production with DC/OS
+          url: /maintain/going-production-with-dcos.html
         - title: Constraining Applications to PX nodes
           url: /scheduler/mesosphere-dcos/constraints.html
         - title: Dynamically creating volumes


### PR DESCRIPTION
Make the DCOS best practice guide a bit easier to find by linking it under ContainerOrchestrators->Mesospher as well.