### PR TITLE
add swarm install page and cleanup standalone docker install page

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -133,7 +133,11 @@
     - title: Docker
       folderitems:
       - title: Install
-        url: /scheduler/docker/install-standalone.html
+        folderitems:
+        - title: Standalone
+          url: /scheduler/docker/install-standalone.html
+        - title: Swarm
+          url: /scheduler/docker/install-swarm.html
       - title: Upgrade
         url: /runc/#upgrade-px-oci
       - title: How To

--- a/_includes/docker-prereqs.md
+++ b/_includes/docker-prereqs.md
@@ -14,7 +14,7 @@ If you are running Docker v1.12, you *must* configure Docker to allow shared mou
 
 **Firewall**
 
-Ensure ports 9001-9015 are open between the Kubernetes nodes that will run Portworx.
+Ensure ports 9001-9015 are open between the nodes that will run Portworx.
 
 **NTP**
 

--- a/_includes/identify-storage-devices.md
+++ b/_includes/identify-storage-devices.md
@@ -1,0 +1,18 @@
+Portworx pools the storage devices on your server and creates a global capacity for containers.
+
+>**Important:**<br/>Back up any data on storage devices that will be pooled. Storage devices will be reformatted!
+
+To view the storage devices on your server, use the `lsblk` command.
+
+For example:
+```
+# lsblk
+    NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+    xvda                      202:0    0     8G  0 disk
+    └─xvda1                   202:1    0     8G  0 part /
+    xvdb                      202:16   0    64G  0 disk
+    xvdc                      202:32   0    64G  0 disk
+```
+Note that devices without the partition are shown under the **TYPE** column as **part**. This example has two non-root storage devices (/dev/xvdb, /dev/xvdc) that are candidates for storage devices.
+
+Identify the storage devices you will be allocating to PX.  PX can run in a heterogeneous environment, so you can mix and match drives of different types.  Different servers in the cluster can also have different drive configurations.

--- a/_includes/px-prereqs.md
+++ b/_includes/px-prereqs.md
@@ -1,0 +1,21 @@
+**Key-value store**
+
+Portworx uses a key-value store for it's clustering metadata. Please have a clustered key-value database (etcd or consul) installed and ready. For etcd installation instructions refer this [doc](/maintain/etcd.html).
+
+**Storage**
+
+At least one of the Portworx nodes should have extra storage available, in a form of unformatted partition or a disk-drive.
+
+Storage devices explicitly given to Portworx will be automatically formatted by PX.
+
+**Shared mounts**
+
+If you are running Docker v1.12, you *must* configure Docker to allow shared mounts propagation (see [instructions](/knowledgebase/shared-mount-propogation.html)), as otherwise Portworx will fail to start.
+
+**Firewall**
+
+Ensure ports 9001-9015 are open between the nodes that will run Portworx.
+
+**NTP**
+
+Ensure all nodes running PX are time-synchronized, and NTP service is configured and running.

--- a/_includes/pxctl/pxctl-after-docker-install.md
+++ b/_includes/pxctl/pxctl-after-docker-install.md
@@ -1,0 +1,34 @@
+After Portworx is running, you can create and delete storage volumes through the Docker volume commands or the **pxctl** command line tool.
+
+With **pxctl**, you can also inspect volumes, the volume relationships with containers, and nodes. For more on using **pxctl**, see the [CLI Reference](/control/status.html).
+
+To view the global storage capacity, run:
+
+```
+# sudo /opt/pwx/bin/pxctl status
+```
+
+The following sample output of `pxctl status` shows that the global capacity for Docker containers is 128 GB.
+
+```
+# /opt/pwx/bin/pxctl status
+Status: PX is operational
+Node ID: 0a0f1f22-374c-4082-8040-5528686b42be
+	IP: 172.31.50.10
+ 	Local Storage Pool: 2 pools
+	POOL	IO_PRIORITY	SIZE	USED	STATUS	ZONE	REGION
+	0	LOW		64 GiB	1.1 GiB	Online	b	us-east-1
+	1	LOW		128 GiB	1.1 GiB	Online	b	us-east-1
+	Local Storage Devices: 2 devices
+	Device	Path		Media Type		Size		Last-Scan
+	0:1	/dev/xvdf	STORAGE_MEDIUM_SSD	64 GiB		10 Dec 16 20:07 UTC
+	1:1	/dev/xvdi	STORAGE_MEDIUM_SSD	128 GiB		10 Dec 16 20:07 UTC
+	total			-			192 GiB
+Cluster Summary
+	Cluster ID: 55f8a8c6-3883-4797-8c34-0cfe783d9890
+	IP		ID					Used	Capacity	Status
+	172.31.50.10	0a0f1f22-374c-4082-8040-5528686b42be	2.2 GiB	192 GiB		Online (This node)
+Global Storage Pool
+	Total Used    	:  2.2 GiB
+	Total Capacity	:  192 GiB
+```

--- a/_includes/runc/runc-configure-portworx.md
+++ b/_includes/runc/runc-configure-portworx.md
@@ -1,0 +1,39 @@
+Now that you have downloaded and installed the PX OCI bundle, you can use the the `px-runc install` command from the bundle to configure systemd to start PX runC.
+
+The _px-runc_ command is a helper-tool that does the following:
+
+1. prepares the OCI directory for runC
+2. prepares the runC configuration for PX
+3. used by systemd to start the PX OCI bundle
+
+Installation example:
+
+```bash
+#  Basic installation
+$ sudo /opt/pwx/bin/px-runc install -c MY_CLUSTER_ID \
+    -k etcd://myetc.company.com:2379 \
+    -s /dev/xvdb -s /dev/xvdc {{ include.sched-flags }}
+```
+
+
+##### Command-line arguments
+
+{% include cmdargs.md %}
+
+##### Examples
+
+Using etcd:
+```
+px-runc install -k etcd://my.company.com:2379 -c MY_CLUSTER_ID -s /dev/sdc -s /dev/sdb2 {{ include.sched-flags }}
+px-runc install -k etcd://70.0.1.65:2379 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8 {{ include.sched-flags }}
+```
+
+Using consul:
+```
+px-runc install -k consul://my.company.com:8500 -c MY_CLUSTER_ID -s /dev/sdc -s /dev/sdb2 {{ include.sched-flags }}
+px-runc install -k consul://70.0.2.65:8500 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8 {{ include.sched-flags }}
+```
+
+##### Modifying the PX configuration
+
+After the initial installation, you can modify the PX configuration file at `/etc/pwx/config.json` (see [details](https://docs.portworx.com/control/config-json.html)) and restart Portworx using `systemctl restart portworx`.

--- a/_includes/runc/runc-enable-portworx.md
+++ b/_includes/runc/runc-enable-portworx.md
@@ -1,0 +1,8 @@
+Once you install the PX OCI bundle and systemd configuration from the steps above, you can start and control PX runC directly via systemd:
+
+```bash
+# Reload systemd configurations, enable and start Portworx service
+$ sudo systemctl daemon-reload
+$ sudo systemctl enable portworx
+$ sudo systemctl start portworx
+```

--- a/_includes/runc/runc-install-bundle.md
+++ b/_includes/runc/runc-install-bundle.md
@@ -1,0 +1,27 @@
+Portworx provides a Docker based installation utility to help deploy the PX OCI
+bundle.  This bundle can be installed by running the following Docker container
+on your host system:
+
+##### To get the 1.2 release
+```bash
+$ latest_stable=$(curl -fsSL 'https://install.portworx.com?type=dock&stork=false' | awk '/image: / {print $2}')
+
+# Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
+$ sudo docker run --entrypoint /runc-entry-point.sh \
+    --rm -i --privileged=true \
+    -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx \
+    $latest_stable
+```
+
+##### To get the 1.3 release
+```bash
+$ latest_stable=$(curl -fsSL 'http://install.portworx.com:8080?type=dock&stork=false' | awk '/image: / {print $2}')
+
+# Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
+$ sudo docker run --entrypoint /runc-entry-point.sh \
+    --rm -i --privileged=true \
+    -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx \
+    $latest_stable
+```
+
+>**Note:**<br/>Running the PX OCI bundle does not require Docker, but Docker will still be required to _install_ the PX OCI bundle.  If you do not have Docker installed on your target hosts, you can download this Docker package and extract it to a root tar ball and manually install the OCI bundle.

--- a/cloud/aws/kops-asg.md
+++ b/cloud/aws/kops-asg.md
@@ -21,7 +21,7 @@ This is a guide to setup a production ready Portworx cluster using Kubernetes (K
 
 ## Prerequisites
 
-{% include k8s-prereqs.md %}
+{% include px-prereqs.md %}
 
 **KOPS cluster in AWS**
 

--- a/cloud/gcp/gke.md
+++ b/cloud/gcp/gke.md
@@ -15,7 +15,7 @@ The steps below will help you enable dynamic provisioning of Portworx volumes in
 
 ## Prerequisites
 
-{% include k8s-prereqs.md %}
+{% include px-prereqs.md %}
 
 ## Create a GKE cluster
 Portworx is supported on GKE cluster provisioned on [Ubuntu Node Images](https://cloud.google.com/kubernetes-engine/docs/node-images).

--- a/runc/index.md
+++ b/runc/index.md
@@ -43,107 +43,15 @@ The installation and setup of PX OCI bundle is a 3-step process:
 <a name="install_step1"></a>
 #### Step 1: Install the PX OCI bundle
 
-Portworx provides a Docker based installation utility to help deploy the PX OCI
-bundle.  This bundle can be installed by running the following Docker container
-on your host system:
-
-##### To get the 1.2 release
-```bash
-$ latest_stable=$(curl -fsSL 'https://install.portworx.com?type=dock&stork=false' | awk '/image: / {print $2}')
-
-# Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
-$ sudo docker run --entrypoint /runc-entry-point.sh \
-    --rm -i --privileged=true \
-    -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx \
-    $latest_stable
-```
-
-##### To get the 1.3 release
-```bash
-$ latest_stable=$(curl -fsSL 'http://install.portworx.com:8080?type=dock&stork=false' | awk '/image: / {print $2}')
-
-# Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
-$ sudo docker run --entrypoint /runc-entry-point.sh \
-    --rm -i --privileged=true \
-    -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx \
-    $latest_stable
-```
-
->**Note:**<br/>Running the PX OCI bundle does not require Docker, but Docker will still be required to _install_ the PX OCI bundle.  If you do not have Docker installed on your target hosts, you can download this Docker package and extract it to a root tar ball and manually install the OCI bundle.
+{% include runc/runc-install-bundle.md %}
 
 #### Step 2: Configure PX under runC
 
-Now that you have downloaded and installed the PX OCI bundle, you can use the the `px-runc install` command from the bundle to configure systemd to start PX runC.
-
-The _px-runc_ command is a helper-tool that does the following:
-
-1. prepares the OCI directory for runC
-2. prepares the runC configuration for PX
-3. used by systemd to start the PX OCI bundle
-
-Installation examples:
-
-```bash
-# EXAMPLE-1: Basic installation
-$ sudo /opt/pwx/bin/px-runc install -c MY_CLUSTER_ID \
-    -k etcd://myetc.company.com:2379 \
-    -s /dev/xvdb -s /dev/xvdc
-
-# EXAMPLE-2: Installation configured for Kubernetes:
-$ sudo /opt/pwx/bin/px-runc install -c MY_CLUSTER_ID \
-    -k etcd://myetc.company.com:2379 \
-    -s /dev/xvdb -s /dev/xvdc -x kubernetes \
-    -v /var/lib/kubelet:/var/lib/kubelet:shared
-```
-
-##### Command-line arguments
-
-The following arguments can be provided to the _px-runc_ helper tool, which will in turn pass them to the PX daemon:
-
-```
-Usage: /opt/pwx/bin/px-runc <install|run> [options]
-```
-
-**Mode of operation**
-* **install**: Creates configuration files and systemd service unit file.
-* **run**: Runs Portworx in foreground; used by systemd to start the portworx service.
-
-{% include cmdargs.md %}
-
-##### Examples
-
-Using etcd:
-```
-px-runc install -k etcd://my.company.com:2379 -c MY_CLUSTER_ID -s /dev/sdc -s /dev/sdb2
-px-runc install -k etcd://70.0.1.65:2379 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8
-px-runc install -k etcd://70.0.1.65:2379 -c MY_CID -f -a -x kubernetes -v /var/lib/kubelet:/var/lib/kubelet:shared
-```
-
-Using consul:
-```
-px-runc install -k consul://my.company.com:8500 -c MY_CLUSTER_ID -s /dev/sdc -s /dev/sdb2
-px-runc install -k consul://70.0.2.65:8500 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8
-px-runc install -k consul://70.0.2.65:8500 -c MY_CID -f -a -x kubernetes -v /var/lib/kubelet:/var/lib/kubelet:shared
-```
-
-##### Modifying the PX configuration
-
-Since PX OCI bundle has _two_ configuration files, it is recommended to initially install the bundle by using the `px-runc install ...` command as described above, rather than supplying custom configuration files.
-
-After the initial installation, you can modify the following files and restart the PX runC container:
-
-* PX configuration file at `/etc/pwx/config.json` (see [details](https://docs.portworx.com/control/config-json.html)), or
-* OCI spec file at `/opt/pwx/oci/config.json` (see [details](https://github.com/opencontainers/runtime-spec/blob/master/spec.md)).
+{% include runc/runc-configure-portworx.md %}
 
 #### Step 3: Starting PX runC
-Once you install the PX OCI bundle and systemd configuration from the steps above, you can start and control PX runC directly via systemd:
 
-```bash
-# Reload systemd configurations, enable and start Portworx service
-$ sudo systemctl daemon-reload
-$ sudo systemctl enable portworx
-$ sudo systemctl start portworx
-```
+{% include runc/runc-enable-portworx.md %}
 
 ##### Advanced usage: Interactive/Foreground mode
 Alternatively, one might prefer to first start the PX interactively (for example, to verify the configuration parameters were OK and the startup was successful), and then install it as a service:

--- a/scheduler/docker/install-standalone.md
+++ b/scheduler/docker/install-standalone.md
@@ -22,71 +22,23 @@ This guide describes installing Portworx using the docker CLI.
 * PX requires a minimum of Docker version 1.10.  Follow the [Docker install](https://docs.docker.com/engine/installation/) guide to install and start the Docker Service.
 * You *must* configure Docker to allow shared mounts propogation. Please follow [these](/knowledgebase/shared-mount-propogation.html) instructions to enable shared mount propogation.  This is needed because PX runs as a container and it will be provisioning storage to other containers.
 
-## Specify storage
+## Identify storage
 
-Portworx pools the storage devices on your server and creates a global capacity for containers. This example uses the two non-root storage devices (/dev/xvdb, /dev/xvdc).
-
->**Important:**<br/>Back up any data on storage devices that will be pooled. Storage devices will be reformatted!
-
-To view the storage devices on your server, use the `lsblk` command.
-
-For example:
-```
-# lsblk
-    NAME                      MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
-    xvda                      202:0    0     8G  0 disk
-    └─xvda1                   202:1    0     8G  0 part /
-    xvdb                      202:16   0    64G  0 disk
-    xvdc                      202:32   0    64G  0 disk
-```
-Note that devices without the partition are shown under the **TYPE** column as **part**. This example has two non-root storage devices (/dev/xvdb, /dev/xvdc) that are candidates for storage devices.
-
-Identify the storage devices you will be allocating to PX.  PX can run in a heterogeneous environment, so you can mix and match drives of different types.  Different servers in the cluster can also have different drive configurations.
+{% include identify-storage-devices.md %}
 
 ## Install PX via OCI runC
 
-PX runs as a container directly via OCI runC.  This ensures that there are no cyclical dependencies between Docker and PX.  [Follow these steps](/runc/index.html) to install PX.
+PX runs as a container directly via OCI runC.  This ensures that there are no cyclical dependencies between Docker and PX.
+
+[Follow these steps](/runc/index.html) to install PX.
 
 ## Adding Nodes
-To add nodes to increase capacity and enable high availability, simply repeat these steps on other servers.  As long as PX is started with the same cluster ID, they will form a cluster.
+
+To add nodes to increase capacity and enable high availability, simply repeat these steps on other servers. As long as PX is started with the same cluster ID, they will form a cluster.
 
 ## Access the pxctl CLI
-After Portworx is running, you can create and delete storage volumes through the Docker volume commands or the **pxctl** command line tool.
 
-With **pxctl**, you can also inspect volumes, the volume relationships with containers, and nodes. For more on using **pxctl**, see the [CLI Reference](/control/status.html).
-
-To view the global storage capacity, run:
-
-```
-# sudo /opt/pwx/bin/pxctl status
-```
-
-The following sample output of `pxctl status` shows that the global capacity for Docker containers is 128 GB.
-
-```
-# /opt/pwx/bin/pxctl status
-Status: PX is operational
-Node ID: 0a0f1f22-374c-4082-8040-5528686b42be
-	IP: 172.31.50.10
- 	Local Storage Pool: 2 pools
-	POOL	IO_PRIORITY	SIZE	USED	STATUS	ZONE	REGION
-	0	LOW		64 GiB	1.1 GiB	Online	b	us-east-1
-	1	LOW		128 GiB	1.1 GiB	Online	b	us-east-1
-	Local Storage Devices: 2 devices
-	Device	Path		Media Type		Size		Last-Scan
-	0:1	/dev/xvdf	STORAGE_MEDIUM_SSD	64 GiB		10 Dec 16 20:07 UTC
-	1:1	/dev/xvdi	STORAGE_MEDIUM_SSD	128 GiB		10 Dec 16 20:07 UTC
-	total			-			192 GiB
-Cluster Summary
-	Cluster ID: 55f8a8c6-3883-4797-8c34-0cfe783d9890
-	IP		ID					Used	Capacity	Status
-	172.31.50.10	0a0f1f22-374c-4082-8040-5528686b42be	2.2 GiB	192 GiB		Online (This node)
-Global Storage Pool
-	Total Used    	:  2.2 GiB
-	Total Capacity	:  192 GiB
-```
-
-You have now completed setup of Portworx on your first server. To increase capacity and enable high availability, repeat the same steps on each of the remaining two servers. Run **pxctl** status to view the cluster status. Then, to continue with examples of running stateful applications and databases with Docker and PX, see [Application Solutions](/application-solutions.html).
+{% include pxctl/pxctl-after-docker-install.md %}
 
 ## Application Examples
 
@@ -94,3 +46,4 @@ After you complete this installation, continue with the set up to run stateful c
 
 * [Scale a Cassandra Database with PX](/applications/cassandra.html)
 * [Run the Docker Registry with High Availability](/applications/docker-registry.html)
+* [Other application Solutions](/application-solutions.html)

--- a/scheduler/docker/install-swarm.md
+++ b/scheduler/docker/install-swarm.md
@@ -9,8 +9,45 @@ redirect_from:
 meta-description: "Follow this step-by-step guide to install Portworx on Docker Swarm or UCP.  Try it for yourself today!"
 ---
 
-For Docker Swarm or UCP, install [Portworx as OCI using this page](/scheduler/docker/install-standalone.html) on each swarm node.
+* TOC
+{:toc}
+
+## Prerequisites
+
+{% include px-prereqs.md %}.
+
+## Identify storage
+
+{% include identify-storage-devices.md %}
+
+## Install
+
+PX runs as a container directly via OCI runC.  This ensures that there are no cyclical dependencies between Docker and PX.
+
+On each swarm node, perform the following steps to install PX.
+
+#### Step 1: Install the PX OCI bundle
+
+{% include runc/runc-install-bundle.md %}
+
+#### Step 2: Configure PX under runC
+
+{% include runc/runc-configure-portworx.md sched-flags="-x swarm" %}
+
+#### Step 3: Starting PX runC
+
+{% include runc/runc-enable-portworx.md %}
 
 >**Note:** If you have previously installed Portworx as a Docker container (as "legacy plugin system", or v1 plugin), and already have PX-volumes allocated and in use by other Docker containers/applications, read [instructions here](/runc/#upgrading-from-px-containers-to-px-oci)
+
+## Adding Nodes
+
+To add nodes to increase capacity and enable high availability, simply repeat these steps on other servers. As long as PX is started with the same cluster ID, they will form a cluster.
+
+## Access the pxctl CLI
+
+{% include pxctl/pxctl-after-docker-install.md %}
+
+## Application Examples
 
 Once you have Portworx up, take a look at an example of running [stateful application with Portworx and Swarm](swarm.html)!

--- a/scheduler/docker/swarm.md
+++ b/scheduler/docker/swarm.md
@@ -12,6 +12,8 @@ meta-description: "You can use Portworx to provide storage for your stateful ser
 
 You can use Portworx to provide storage for your Docker Swarm services. Portworx pools your servers capacity and turns your servers or cloud instances into converged, highly available compute and storage nodes. This section describes how to deploy PX within a Docker Swarm cluster and have PX provide highly available volumes to any application deployed via Docker Swarm.
 
+## Install Portworx
+
 Below steps demonstrate how to set up a three-node cluster for [Jenkins](https://jenkins.io/) and use a Portworx volume.
 
 ### Create a volume

--- a/scheduler/kubernetes/install.md
+++ b/scheduler/kubernetes/install.md
@@ -20,7 +20,7 @@ Follow [this interactive tutorial](https://www.katacoda.com/portworx/scenarios/d
 
 ## Prerequisites
 
-{% include k8s-prereqs.md %}.
+{% include px-prereqs.md %}.
 
 ## Install
 

--- a/scheduler/kubernetes/openshift-install.md
+++ b/scheduler/kubernetes/openshift-install.md
@@ -14,7 +14,7 @@ meta-description: "Find out how to install PX within a Openshift cluster and hav
 
 ## Prerequisites
 
-{% include k8s-prereqs.md %}
+{% include px-prereqs.md %}
 
 **Version**
 


### PR DESCRIPTION
Main changes

1. Extract common text between standalone and swarm
2. Add a end to end swarm page
3. Parameterize include file and add `-x swarm` for swarm page
4. Remove unnecessary description of px-run run mode and kubernetes on the standalone page.

Signed-off-by: Harsh Desai <harsh@portworx.com>