### PR TITLE
Fixing http://install.portworx.com:8080 references

### DIFF
--- a/_includes/k8s-spec-generate.md
+++ b/_includes/k8s-spec-generate.md
@@ -1,6 +1,6 @@
 To generate the spec file for the 1.2 release, head on to [1.2 install page](https://install.portworx.com).
 
-To generate the spec file for the 1.3 release, head on to [1.3 install page](http://install.portworx.com:8080).
+To generate the spec file for the 1.3 release, head on to [1.3 install page](https://install.portworx.com:8443).
 
 Alternately, you can use curl to generate the spec as described in [Generating Portworx Kubernetes spec using curl](/scheduler/kubernetes/px-k8s-spec-curl.html).
 

--- a/_includes/runc/runc-install-bundle.md
+++ b/_includes/runc/runc-install-bundle.md
@@ -15,7 +15,7 @@ $ sudo docker run --entrypoint /runc-entry-point.sh \
 
 ##### To get the 1.3 release
 ```bash
-$ latest_stable=$(curl -fsSL 'http://install.portworx.com:8080?type=dock&stork=false' | awk '/image: / {print $2}')
+$ latest_stable=$(curl -fsSL 'https://install.portworx.com:8443?type=dock&stork=false' | awk '/image: / {print $2}')
 
 # Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
 $ sudo docker run --entrypoint /runc-entry-point.sh \

--- a/scheduler/kubernetes/px-k8s-spec-curl.md
+++ b/scheduler/kubernetes/px-k8s-spec-curl.md
@@ -21,7 +21,7 @@ $ VER=$(kubectl version --short | awk -Fv '/Server Version: /{print $3}')
 $ curl -L -o px-spec.yaml "https://install.portworx.com?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
 
 # For the latest 1.3 release
-$ curl -L -o px-spec.yaml "http://install.portworx.com:8080?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
+$ curl -L -o px-spec.yaml "https://install.portworx.com:8443?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
 ```
 
 Below are all parameters that can be given in the query string.

--- a/scheduler/kubernetes/uninstall.md
+++ b/scheduler/kubernetes/uninstall.md
@@ -56,7 +56,7 @@ The commands used in this section are DISRUPTIVE and will lead to loss of all yo
 You can use the following command to wipe your entire Portworx cluster.
 
 ```
-curl -fsL http://install.portworx.com:8080/px-wipe | bash
+curl -fsL https://install.portworx.com:8443/px-wipe | bash
 ```
 
 Above command will run a Kubernetes Job that will perform following operations:

--- a/scheduler/kubernetes/upgrade-1.3.md
+++ b/scheduler/kubernetes/upgrade-1.3.md
@@ -21,7 +21,7 @@ You are running Portworx as OCI if the Portworx daemonset image is _portworx/oci
 To upgrade, run the below curl command.
 
 ```
-curl -fsL http://install.portworx.com:8080/upgrade | bash -s 
+curl -fsL https://install.portworx.com:8443/upgrade | bash -s 
 ```
 
 This runs a script that will start a Kubernetes Job to perform the following operations:
@@ -45,7 +45,7 @@ You can invoke the upgrade script with the _-t_ to override the default Portworx
 For example below command upgrades Portworx to _portworx/oci-monitor:1.3.0-rc5_ image.
 
 ```
-curl -fsL http://install.portworx.com:8080/upgrade | bash -s -- -t 1.3.0-rc5
+curl -fsL https://install.portworx.com:8443/upgrade | bash -s -- -t 1.3.0-rc5
 ```
 
 ### Disable scaling down of shared Portworx applications during the upgrade
@@ -54,7 +54,7 @@ You can invoke the upgrade script with _--scaledownsharedapps off_ to skip scali
 
 For example:
 ```
-curl -fsL http://install.portworx.com:8080/upgrade | bash -s -- --scaledownsharedapps off
+curl -fsL https://install.portworx.com:8443/upgrade | bash -s -- --scaledownsharedapps off
 ```
 >**Reboot requirement:**<br/>By default, the upgrade process scales down shared applications as that avoids a node reboot when upgrading between major Portworx versions. Disabling that flag would mean the node would need a reboot before Portworx comes up with the new major version.
 
@@ -107,7 +107,7 @@ minion2 192.168.56.71   3.316327   4.1 GB     ...   1.2.11.10-421c67f   Online
 If the upgrade job crashes unexpectedly and fails to restore shared applications back to their original replica counts, you can run the following command to restore them.
 
 ```
-curl -fsL http://install.portworx.com:8080/upgrade | bash -s -- --scaledownsharedapps off
+curl -fsL https://install.portworx.com:8443/upgrade | bash -s -- --scaledownsharedapps off
 ```
 
 <a name="docker-to-oci"></a>


### PR DESCRIPTION
Moved all http://install.portworx.com:8080 (plaintext) references to https://install.portworx.com:8443 (SSL)