### PR TITLE
Add objectstore examples with 'mc' client

### DIFF
--- a/manage/objectstore.md
+++ b/manage/objectstore.md
@@ -64,13 +64,13 @@ The servers are created with the "us-east-1" region currently.
 The objectstore does not have SSL certificates set up, so you'll need to configure your client accordingly.
 
 ## Test the objectore from an S3 client
-Use the sample steps below to test the objectstore from the 'mc' client utility.
+Use the sample steps below to test the objectstore from the ``mc`` client utility.
 
 Download the ``mc`` utility
 ```
 wget https://dl.minio.io/client/mc/release/linux-amd64/mc 
 chmod +x mc 
-``
+```
 
 Configure the ``mc`` client to talk to the objectstore
 ```

--- a/manage/objectstore.md
+++ b/manage/objectstore.md
@@ -74,9 +74,13 @@ chmod +x mc
 
 Configure the ``mc`` client to talk to the objectstore
 ```
-./mc config host add portworxs3 http://172.20.0.27:9010 SNKM04SP9P8PCNW6PKDO va11VEismRQm/vFxheby0PMFXEdl2nyKw3AG8udq --api "s3v2"
+./mc config host add portworxs3 http://<node_ip>:9010 \
+     SNKM04SP9P8PCNW6PKDO va11VEismRQm/vFxheby0PMFXEdl2nyKw3AG8udq \
+     --api "s3v2"
 Added `portworxs3` successfully.
 ```
+where ``node_ip`` corresponds to the host IP address.
+Note the ``api "s3v2"`` version.
 
 Create and Show a bucket
 ```

--- a/manage/objectstore.md
+++ b/manage/objectstore.md
@@ -63,6 +63,29 @@ Use these credentials to login to the object browser as well as running any s3 c
 The servers are created with the "us-east-1" region currently.
 The objectstore does not have SSL certificates set up, so you'll need to configure your client accordingly.
 
+## Test the objectore from an S3 client
+Use the sample steps below to test the objectstore from the 'mc' client utility.
+
+Download the ``mc`` utility
+```
+wget https://dl.minio.io/client/mc/release/linux-amd64/mc 
+chmod +x mc 
+``
+
+Configure the ``mc`` client to talk to the objectstore
+```
+./mc config host add portworxs3 http://172.20.0.27:9010 SNKM04SP9P8PCNW6PKDO va11VEismRQm/vFxheby0PMFXEdl2nyKw3AG8udq --api "s3v2"
+Added `portworxs3` successfully.
+```
+
+Create and Show a bucket
+```
+./mc mb portworxs3/test
+Bucket created successfully `portworxs3/test`.
+./mc ls portworxs3
+[2018-04-04 21:34:13 UTC]     0B test/
+```
+
 ## Stop the objectstore
 You can stop the server on each node by running the stop command.
 If the object server is still running on other nodes you'll get a message saying that the volumes will not be detached since they are being used by the objectstore on the other nodes.


### PR DESCRIPTION
Main goal was to make sure 'mc' config handshake is documented as "--api s3v2"