### PR TITLE
Add 1.4 install references to docs

### DIFF
--- a/_includes/k8s-spec-generate.md
+++ b/_includes/k8s-spec-generate.md
@@ -1,8 +1,14 @@
 {{ include.asg-addendum }}
 
-To generate the spec file for the 1.3 release, head on to [1.3 install page](https://install.portworx.com/1.3/).
+To generate the spec file, head on to the below URLs for the PX release you wish to use.
 
-To generate the spec file for the 1.2 release, head on to [1.2 install page](https://install.portworx.com/1.2/).
+* [1.4 Tech Preview](https://install.portworx.com/1.4/).
+{% unless include.skip13 == "true" %}
+* [1.3 Stable](https://install.portworx.com/1.3/).
+{% endunless %}
+{% unless include.skip12 == "true" %}
+* [1.2 Stable](https://install.portworx.com/1.2/).
+{% endunless %}
 
 Alternately, you can use curl to generate the spec as described in [Generating Portworx Kubernetes spec using curl](/scheduler/kubernetes/px-k8s-spec-curl.html).
 

--- a/_includes/runc/runc-install-bundle.md
+++ b/_includes/runc/runc-install-bundle.md
@@ -2,7 +2,18 @@ Portworx provides a Docker based installation utility to help deploy the PX OCI
 bundle.  This bundle can be installed by running the following Docker container
 on your host system:
 
-##### To get the 1.3 release
+##### To get the 1.4 tech preview release
+```bash
+$ latest_stable=$(curl -fsSL 'https://install.portworx.com/1.4/?type=dock&stork=false' | awk '/image: / {print $2}')
+
+# Download OCI bits (reminder, you will still need to run `px-runc install ..` after this step)
+$ sudo docker run --entrypoint /runc-entry-point.sh \
+    --rm -i --privileged=true \
+    -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx \
+    $latest_stable
+```
+
+##### To get the 1.3 stable release
 ```bash
 $ latest_stable=$(curl -fsSL 'https://install.portworx.com/1.3/?type=dock&stork=false' | awk '/image: / {print $2}')
 
@@ -13,7 +24,7 @@ $ sudo docker run --entrypoint /runc-entry-point.sh \
     $latest_stable
 ```
 
-##### To get the 1.2 release
+##### To get the 1.2 stable release
 ```bash
 $ latest_stable=$(curl -fsSL 'https://install.portworx.com/1.2/?type=dock&stork=false' | awk '/image: / {print $2}')
 

--- a/cloud/gcp/gke.md
+++ b/cloud/gcp/gke.md
@@ -39,9 +39,7 @@ Portworx takes in a disk spec which gets used to provision GCP persistent disks 
 
 ### Generate the spec
 
-{% include k8s-spec-generate.md asg-addendum="
-We will supply the template(s) explained in previous section, when we create the Portworx spec.
-"%}
+{% include k8s-spec-generate.md  asg-addendum="We will supply the template(s) explained in previous section, when we create the Portworx spec." skip12="true" skip13="true" %}
 
 ### Applying the spec
 

--- a/scheduler/kubernetes/openshift-install.md
+++ b/scheduler/kubernetes/openshift-install.md
@@ -56,7 +56,7 @@ oc create secret docker-registry regcred --docker-server=registry.connect.redhat
 
 >**Note:**<br/> Make sure to select "[x] Openshift" and provide "Kubernetes docker-registry secret: _regcred_" while generating the spec  (i.e. the spec-URL should have the _osft=true_ and _rsec=regcred_ parameters defined).
 
-{% include k8s-spec-generate.md %}
+{% include k8s-spec-generate.md skip12="true" %}
 
 
 ### Apply the spec

--- a/scheduler/kubernetes/px-k8s-spec-curl.md
+++ b/scheduler/kubernetes/px-k8s-spec-curl.md
@@ -16,10 +16,13 @@ Below is an example of using curl to generate the Portworx spec file. Review the
 
 ```bash
 $ VER=$(kubectl version --short | awk -Fv '/Server Version: /{print $3}')
-# For the 1.3 release
+# For the 1.4 tech preview release
+$ curl -L -o px-spec.yaml "https://install.portworx.com/1.4/?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
+
+# For the 1.3 stable release
 $ curl -L -o px-spec.yaml "https://install.portworx.com/1.3/?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
 
-# For the 1.2 release
+# For the 1.2 stable release
 $ curl -L -o px-spec.yaml "https://install.portworx.com/1.2/?c=mycluster&k=etcd://<ETCD_ADDRESS>:<ETCD_PORT>&kbver=$VER"
 
 ```

--- a/scheduler/kubernetes/uninstall.md
+++ b/scheduler/kubernetes/uninstall.md
@@ -56,7 +56,7 @@ The commands used in this section are DISRUPTIVE and will lead to loss of all yo
 You can use the following command to wipe your entire Portworx cluster.
 
 ```
-curl -fsL https://install.portworx.com/1.3/px-wipe | bash
+curl -fsL https://install.portworx.com/px-wipe | bash
 ```
 
 Above command will run a Kubernetes Job that will perform following operations:

--- a/scheduler/kubernetes/upgrade-1.3.md
+++ b/scheduler/kubernetes/upgrade-1.3.md
@@ -18,11 +18,10 @@ This guide describes the procedure to upgrade Portworx running as OCI container 
 
 You are running Portworx as OCI if the Portworx daemonset image is _portworx/oci-monitor_. If not, you first need to [migrate to OCI](/scheduler/kubernetes/upgrade-1.3.html#docker-to-oci).
 
-To upgrade, run the below curl command.
+To upgrade to the 1.3 stable release, run the curl command: `curl -fsL https://install.portworx.com/1.3/upgrade | bash -s`
 
-```
-curl -fsL https://install.portworx.com/1.3/upgrade | bash -s 
-```
+To upgrade to the 1.4 tech preview release, run the curl command: `curl -fsL https://install.portworx.com/upgrade | bash -s -- -t 1.4.0-rc1`
+
 
 This runs a script that will start a Kubernetes Job to perform the following operations:
 
@@ -42,10 +41,10 @@ This script will also monitor the above operations.
 ### Specify a different Portworx upgrade image
 
 You can invoke the upgrade script with the _-t_ to override the default Portworx image.
-For example below command upgrades Portworx to _portworx/oci-monitor:1.3.1.1_ image.
+For example below command upgrades Portworx to _portworx/oci-monitor:1.4.0-rc1_ image.
 
 ```
-curl -fsL https://install.portworx.com/1.3/upgrade | bash -s -- -t 1.3.1.1
+curl -fsL https://install.portworx.com/upgrade | bash -s -- -t 1.4.0-rc1
 ```
 
 ### Disable scaling down of shared Portworx applications during the upgrade


### PR DESCRIPTION
This PR adds 1.4 spec URLs to docs.

It also enables to skip PX versions for certain pages. For e.g for GKE, we skip 1.2 and 1.3 since we don't support that.

Signed-off-by: Harsh Desai <harsh@portworx.com>