### PR TITLE
Fixing 'oc patch' screen-render for OSFT

### DIFF
--- a/scheduler/kubernetes/openshift-install.md
+++ b/scheduler/kubernetes/openshift-install.md
@@ -61,8 +61,14 @@ oc create secret docker-registry regcred --docker-server=registry.connect.redhat
 
 ### Apply the spec
 
->**Note:**<br/> Openshift Container Platform 3.9 started restricting where Daemonsets can install (see [reference](https://docs.openshift.com/container-platform/3.9/dev_guide/daemonsets.html)), which will prevent the installation of Portworx Daemonset.
-To enable Daemonsets on "kube-system" namespace run: `oc patch namespace kube-system -p '{"metadata": {"annotations": {"openshift.io/node-selector": ""}}}'`<br>Alternatively, add the following label to the individual nodes where you want Portworx to run: `oc label nodes mynode1 node-role.kubernetes.io/compute=true`
+>**Note:**<br/> Openshift Container Platform 3.9 started restricting where Daemonsets can install
+(see [reference](https://docs.openshift.com/container-platform/3.9/dev_guide/daemonsets.html)),
+which will prevent the installation of Portworx Daemonset.
+>
+> 1. To enable Daemonsets on "kube-system" namespace run: `oc patch namespace kube-system -p \`<br>
+`'{"metadata": {"annotations": {"openshift.io/node-selector": ""}}}'`
+> 2. Alternatively, add the following label to the individual nodes where you want Portworx to run:
+`oc label nodes mynode1 node-role.kubernetes.io/compute=true`
 
 Once you have generated the spec file, deploy Portworx.	
 ```bash


### PR DESCRIPTION
Fixing "off the screen" render for "oc patch" command on OSFT-install page.