### PR TITLE
fix annotation, px->portworx

### DIFF
--- a/scheduler/kubernetes/snaps-cloud.md
+++ b/scheduler/kubernetes/snaps-cloud.md
@@ -44,7 +44,7 @@ metadata:
   name: mysql-snapshot
   namespace: default
   annotations:
-    px/snapshot-type: cloud
+    portworx/snapshot-type: cloud
 spec:
   persistentVolumeClaimName: mysql-data
 ```


### PR DESCRIPTION
The example as shown does not work. Changing px/snapshot-type to portworx/snapshot-type works. The docs actually correctly states that it should be the latter just a few lines prior.