### PR TITLE
Promote katacoda tutorials on front page

### DIFF
--- a/_includes/k8s/katacoda.md
+++ b/_includes/k8s/katacoda.md
@@ -1,0 +1,7 @@
+Following are some interactive tutorials that give an overview about Portworx on Kubernetes.
+
+* [Basic Install of Portworx on Kubernetes](https://www.katacoda.com/portworx/scenarios/deploy-px-k8s) gives a high level overview on installing Portworx on Kubernetes.
+* [PVCs with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-vol-basic) shows how to create persistent volumes using Portworx on Kubernetes.
+* [Deploy Mongo using Portworx and Helm](https://www.katacoda.com/portworx/scenarios/px-helm-mongo) shows how to deploy MongoDB using Portworx and goes through failover scenarios and snapshots.
+* [Deploy HA PostgreSQL with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-postgres-all-in-one) shows how to deploy PostgreSQL using Portworx.
+* [SQL Server High-Availabilty with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-sql-ha) goes through SQL Server deployment and high-availibility with Portworx, with a sub 2 minute failover.

--- a/index.md
+++ b/index.md
@@ -30,6 +30,10 @@ Portworx technology:
 * Provides programmatic control on your storage resources - volumes and other stateful services can be created and consumed directly via the scheduler and orchestration software tool chain.
 * Is radically simple - Portworx is deployed just like any other container - and managed by your scheduler of choice.
 
+## Interactive tutorials
+
+{% include k8s/katacoda.md %}}
+
 ## Cloud Native Storage
 {%
     include youtubePlayer.html 

--- a/scheduler/kubernetes/px-k8s-interactive.md
+++ b/scheduler/kubernetes/px-k8s-interactive.md
@@ -14,10 +14,4 @@ meta-description: "Run through Portworx interactive tutorials on Kubernetes."
 
 ## Interactive Tutorials
 
-Following are some interactive tutorials that give an overview about Portworx on Kubernetes.
-
-* [Basic Install of Portworx on Kubernetes](https://www.katacoda.com/portworx/scenarios/deploy-px-k8s) gives a high level overview on installing Portworx on Kubernetes.
-* [PVCs with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-vol-basic) shows how to create persistent volumes using Portworx on Kubernetes.
-* [Deploy Mongo using Portworx and Helm](https://www.katacoda.com/portworx/scenarios/px-helm-mongo) shows how to deploy MongoDB using Portworx and goes through failover scenarios and snapshots.
-* [Deploy HA PostgreSQL with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-postgres-all-in-one) shows how to deploy PostgreSQL using Portworx.
-* [SQL Server High-Availabilty with Portworx](https://www.katacoda.com/portworx/scenarios/px-k8s-sql-ha) goes through SQL Server deployment and high-availibility with Portworx, with a sub 2 minute failover.
+{% include k8s/katacoda.md %}


### PR DESCRIPTION
This brings katacoda tutorials right on the front page. Screenshot below.

![screen shot 2018-07-19 at 6 17 21 pm](https://user-images.githubusercontent.com/26801153/42978158-3df48dcc-8b80-11e8-875b-3befb789c267.png)

Signed-off-by: Harsh Desai <harsh@portworx.com>