### PR TITLE
add leadlander analytics tag alongside google analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,6 +111,9 @@ url: https://docs.portworx.com
 # Google services
 google_analytics: UA-64247527-1
 
+# Leadlander config
+leadlander_id: 31806
+
 # Endless thanks for this incredible Theme!  http://idratherbewriting.com/documentation-theme-jekyll/
 
 plugins:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,6 +45,10 @@
 {% include google_analytics.html %}
 {% endif %}
 
+{% if site.leadlander_id and jekyll.environment == 'production' %}
+{% include leadlander.html %}
+{% endif %}
+
 {% if page.meta-description %}
     <meta name="description" content="{{ page.meta-description }}"/>
 {% endif %}

--- a/_includes/leadlander.html
+++ b/_includes/leadlander.html
@@ -1,0 +1,14 @@
+<!-- the leadlander_id gets auto inserted from the config file -->
+
+{% if site.leadlander_id %}
+
+<script type="text/javascript" language="javascript">
+  var sf14gv = {{ site.leadlander_id }};
+  (function() {
+    var sf14g = document.createElement('script'); sf14g.type = 'text/javascript'; sf14g.async = true;
+    sf14g.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 't.sf14g.com/sf14g.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sf14g, s);
+  })();
+</script>
+
+{% endif %}


### PR DESCRIPTION
This PR adds the tracking code for leadlander into the `head.html` page.

It works the same way as the google analytics setup in that:

 * The account id is configured via `_config.yaml` using the `leadlander_id` property
 * There is an include (`_includes/leadlander.html`) brought in via `head.html` 
 * The include is only used if the `leadlander_id` property is defined in `_config.yaml`