### PR TITLE
GKE doc improvements

### DIFF
--- a/_includes/px-k8s-prereqs.md
+++ b/_includes/px-k8s-prereqs.md
@@ -2,18 +2,17 @@
 
 Portworx uses a key-value store for it's clustering metadata. Please have a clustered key-value database (etcd or consul) installed and ready. For etcd installation instructions refer this [doc](/maintain/etcd.html).
 
-**Shared mounts**
-
-Portworx 1.3 and higher automatically enables shared mounts.
-
-If you are installing Portworx 1.2, you *must* configure Docker to allow shared mounts propagation (see [instructions](/knowledgebase/shared-mount-propagation.html)), as otherwise Portworx will fail to start.
+{% if include.skip_firewall != "true"  %}
 
 **Firewall**
 
 Ensure ports 9001-9015 are open between the nodes that will run Portworx. Your nodes should also be able to reach the port KVDB is running on (for example etcd usually runs on port 2379).
+{% endif %}
 
 {{ include.firewall-custom-steps }}
 
+{% if include.skip_ntp != "true"  %}
 **NTP**
 
 Ensure all nodes running PX are time-synchronized, and NTP service is configured and running.
+{% endif %}

--- a/cloud/gcp/gke.md
+++ b/cloud/gcp/gke.md
@@ -13,17 +13,11 @@ The steps below will help you enable dynamic provisioning of Portworx volumes in
 
 ## Prerequisites
 
-{% include px-k8s-prereqs.md %}
-
-{% include asg/asg-prereqs.md %}
-
-**PX Version**
-
-Support for GKE is available only in portworx release version 1.4 and above.
+{% include px-k8s-prereqs.md skip_ntp="true" skip_firewall="true" %}
 
 ## Create a GKE cluster
 
-Following two points are important when creating your GKE cluster.
+Following points are important when creating your GKE cluster.
 
 1. Portworx is supported on GKE cluster provisioned on [Ubuntu Node Images](https://cloud.google.com/kubernetes-engine/docs/node-images). So it is important to specify the node image as **Ubuntu** when creating clusters.
 
@@ -31,34 +25,27 @@ Following two points are important when creating your GKE cluster.
 
 3. Portworx requires a ClusterRoleBinding for your user. Without this `kubectl apply ...` command fails with an error like ```clusterroles.rbac.authorization.k8s.io "portworx-pvc-controller-role" is forbidden```.
 
-Create a ClusterRoleBinding for your user using the following commands:
+    Create a ClusterRoleBinding for your user using the following commands:
+    ```
+    # get current google identity
+    $ gcloud info | grep Account
+    Account: [myname@example.org]
 
- ```
-   # get current google identity
-   $ gcloud info | grep Account
-   Account: [myname@example.org]
-
-   # grant cluster-admin to your current identity
-   $ kubectl create clusterrolebinding myname-cluster-admin-binding \
-      --clusterrole=cluster-admin --user=myname@example.org
-   Clusterrolebinding "myname-cluster-admin-binding" created
-   ```
+    # grant cluster-admin to your current identity
+    $ kubectl create clusterrolebinding myname-cluster-admin-binding \
+        --clusterrole=cluster-admin --user=myname@example.org
+    Clusterrolebinding "myname-cluster-admin-binding" created
+    ```
 
 More information about creating GKE clusters can be found [here](https://cloud.google.com/kubernetes-engine/docs/clusters/operations).
 
 ## Install
 
-Portworx gets deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). Following sections describe how to generate the spec files and apply them.
-
-### Disk template
-
-Portworx takes in a disk spec which gets used to provision GCP persistent disks dynamically.
-
-{% include asg/gcp-template.md %}
+Portworx gets deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). We will use below sections to generate the specs.
 
 ### Generate the spec
 
-{% include k8s-spec-generate.md  asg-addendum="We will supply the template(s) explained in previous section, when we create the Portworx spec." skip12="true" skip13="true" %}
+{% include k8s-spec-generate.md %}
 
 ### Applying the spec
 


### PR DESCRIPTION
1. shared mounts are not relevant for any install
2. firewall and ntp are not relevant for GKE
3. Removing entire section that describes how to generate ASG spec for GKE since the spec generator now covers that

The updated GKE page now looks like below

![screen shot 2018-10-10 at 6 08 13 pm](https://user-images.githubusercontent.com/26801153/46774495-878c4b00-ccb7-11e8-8ca0-3087ed2a87fe.png)


Signed-off-by: Harsh Desai <harsh@portworx.com>