### PR TITLE
Revamp Secrets hierarchy. Add docs for IBM Key Protect.

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -377,6 +377,8 @@
       url: /secrets/portworx-with-kubernetes-secrets.html
     - title: Portworx with DC/OS Secrets
       url: /secrets/portworx-with-dcos-secrets.html
+    - title: Portworx with IBM Key Protect
+      url: /secrets/portworx-with-ibm-kp.html
   - title: Lighthouse
     folderitems:
     # - title: Install Lighthouse

--- a/_includes/secrets/intro.md
+++ b/_includes/secrets/intro.md
@@ -1,0 +1,14 @@
+This guide will give you an overview of how to use Encryption feature for Portworx volumes.
+Under the hood Portworx uses libgcrypt library to interface with the dm-crypt module for creating, accessing and managing encrypted devices. Portworx uses the LUKS format of dm-crypt and AES-256 as the cipher with xts-plain64 as the cipher mode.
+
+Portworx has two different kinds of encrypted volumes
+
+- **Encrypted Volumes**
+
+Encrypted volumes are regular volumes which can be accessed from only one node.
+
+- **Encrypted Shared Volumes**
+
+Encrypted shared volume allows access to the same encrypted volume from multiple nodes.
+
+All the encrypted volumes are protected by a passphrase. Portworx uses the passphrase to encrypt/decrypt the volumes. It is recommended to store these passphrases in a secure secret store. To know more about the supported secret providers and how to configure them with Portworx, refer to the [Setup Secrets Provider](/secrets) guide.

--- a/_includes/secrets/k8s/enc-storage-class-spec.md
+++ b/_includes/secrets/k8s/enc-storage-class-spec.md
@@ -1,0 +1,13 @@
+Create a storage class with `secure` parameter set to `true`.
+```yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-secure-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  secure: "true"
+  repl: "3"
+```
+
+To create a **shared encrypted volume** set the `shared` parameter to `true` as well.

--- a/_includes/secrets/k8s/other-providers-pvc-encryption.md
+++ b/_includes/secrets/k8s/other-providers-pvc-encryption.md
@@ -1,0 +1,15 @@
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: secure-mysql-pvc
+  annotations:
+    px/secret-name: your-secret-key
+spec:
+  storageClassName: portworx-sc
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```

--- a/_includes/secrets/k8s/storage-class-encryption.md
+++ b/_includes/secrets/k8s/storage-class-encryption.md
@@ -1,0 +1,28 @@
+#### Step 2: Create a StorageClass
+
+{% include secrets/k8s/enc-storage-class-spec.md %}
+
+#### Step 3: Create Persistent Volume Claim
+Create a PVC that uses the above `px-secure-sc` storage class.
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: secure-pvc
+spec:
+  storageClassName: px-secure-sc
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+#### Step 4: Verify the volume
+Once the PVC has been created, verify the volume created in Portworx is encrypted.
+```
+# PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='{.items[0].metadata.name}')
+# kubectl exec $PX_POD -n kube-system -- /opt/pwx/bin/pxctl volume list
+ID                 NAME                                      ...  ENCRYPTED  ...
+10852605918962284  pvc-5a885584-44ca-11e8-a17b-080027ee1df7  ...  yes        ...
+```

--- a/_includes/secrets/per-volume-secret.md
+++ b/_includes/secrets/per-volume-secret.md
@@ -1,14 +1,14 @@
-For encrypting volumes using specific secret keys, you need to provide that key for every create and attach commands.
+For encrypting volumes using specific secret keys, you need to provide that key for every create and attach command.
 
-To create an **encrypted** volume using a specific secret through pxctl, run the following command
+To create an **encrypted** volume using a specific secret through Portworx CLI, run the following command
 
 ```
 # /opt/pwx/bin/pxctl volume create --secure --secret_key key1 enc_vol
-Volume successfully created: 374663852714325215
+Encrypted volume successfully created: 374663852714325215
 
 ```
 
-To create a **shared encrypted** volume run the followin command
+To create a **shared encrypted** volume run the following command
 
 ```
 # /opt/pwx/bin/pxctl volume create --shared --secret_key key1 --secure --size 10 enc_shared_vol
@@ -33,6 +33,5 @@ To attach and mount an encrypted volume through docker, run the following comman
 
 ```
 # docker run --rm -it -v secure=true,secret_key=key1,name=enc_vol:/mnt busybox
-/ #
 
 ```

--- a/_includes/secrets/per-volume-secret.md
+++ b/_includes/secrets/per-volume-secret.md
@@ -1,0 +1,38 @@
+For encrypting volumes using specific secret keys, you need to provide that key for every create and attach commands.
+
+To create an **encrypted** volume using a specific secret through pxctl, run the following command
+
+```
+# /opt/pwx/bin/pxctl volume create --secure --secret_key key1 enc_vol
+Volume successfully created: 374663852714325215
+
+```
+
+To create a **shared encrypted** volume run the followin command
+
+```
+# /opt/pwx/bin/pxctl volume create --shared --secret_key key1 --secure --size 10 enc_shared_vol
+Encrypted Shared volume successfully created: 77957787758406722
+```
+
+To create an **encrypted** volume using a specific secret through docker, run the following command
+
+```
+# docker volume create --volume-driver pxd secret_key=key1,name=enc_vol
+
+```
+
+To create an **encrypted shared** volume using a specific secret through docker, run the following command
+
+```
+# docker volume create --volume-driver pxd shared=true,secret_key=key1,name=enc_shared_vol
+
+```
+
+To attach and mount an encrypted volume through docker, run the following command
+
+```
+# docker run --rm -it -v secure=true,secret_key=key1,name=enc_vol:/mnt busybox
+/ #
+
+```

--- a/_includes/secrets/set-ibm-cluster-wide-secret.md
+++ b/_includes/secrets/set-ibm-cluster-wide-secret.md
@@ -1,0 +1,11 @@
+Use the following command to set the cluster wide secret key when using IBM Key Protect
+
+```
+$ /opt/pwx/bin/pxctl secrets set-cluster-key --secret <passphrase>
+Successfully set cluster secret key!
+
+```
+
+The `<passphrase>` in the above command will be used for encrypting the volumes. The cluster wide secret key needs to be set only once.
+
+__Important: DO NOT overwrite the cluster wide secret key, else any existing volumes using it will not be usable__

--- a/_includes/secrets/volume-cluster-wide-secret.md
+++ b/_includes/secrets/volume-cluster-wide-secret.md
@@ -1,4 +1,4 @@
-Cluster wide secret key is basically a key value pair where the value part is the secret that is used as a passphrase for encrypting volumes. A cluster wide secret key is a common key that can be used to encrypt all the volumes.
+Cluster wide secret key is basically a key value pair where the value part is the secret that is used as a passphrase for encrypting volumes. A cluster wide secret key is the default key that can be used to encrypt all the volumes.
 
 To create a volume using a cluster wide secret key run the following command
 
@@ -10,7 +10,7 @@ ID	      	     		NAME		SIZE	HA SHARED	ENCRYPTED	IO_PRIORITY	SCALE	STATUS
 822124500500459627	 encrypted_volume	10 GiB	1    no yes		LOW		1	up - detached
 ```
 
-To create a **shared encrypted** volume run the followin command
+To create a **shared encrypted** volume using the cluster wide secret key run the following command
 
 ```
 # /opt/pwx/bin/pxctl volume create --shared --secure --size 10 encrypted_volume
@@ -26,4 +26,4 @@ Volume successfully attached at: /dev/mapper/pxd-enc822124500500459627
 Volume encrypted_volume successfully mounted at /mnt
 ```
 
-When using cluster wide secret keys, the secret key does not need to be provided in any of the commands. When no secret key is provided in the pxctl volume commands, PX defaults to using the cluster wide secret key **if set**
+When using cluster wide secret key, the secret key does not need to be provided in any of the commands. When no secret key is provided in the pxctl volume commands, PX defaults to using the cluster wide secret key **if set**

--- a/_includes/secrets/volume-cluster-wide-secret.md
+++ b/_includes/secrets/volume-cluster-wide-secret.md
@@ -1,0 +1,29 @@
+Cluster wide secret key is basically a key value pair where the value part is the secret that is used as a passphrase for encrypting volumes. A cluster wide secret key is a common key that can be used to encrypt all the volumes.
+
+To create a volume using a cluster wide secret key run the following command
+
+```
+# /opt/pwx/bin/pxctl volume create --secure --size 10 encrypted_volume
+Volume successfully created: 822124500500459627
+# /opt/pwx/bin/pxctl volume list
+ID	      	     		NAME		SIZE	HA SHARED	ENCRYPTED	IO_PRIORITY	SCALE	STATUS
+822124500500459627	 encrypted_volume	10 GiB	1    no yes		LOW		1	up - detached
+```
+
+To create a **shared encrypted** volume run the followin command
+
+```
+# /opt/pwx/bin/pxctl volume create --shared --secure --size 10 encrypted_volume
+Encrypted Shared volume successfully created: 77957787758406722
+```
+
+You can attach and mount the encrypted volume
+
+```
+# /opt/pwx/bin/pxctl host attach encrypted_volume
+Volume successfully attached at: /dev/mapper/pxd-enc822124500500459627
+# /opt/pwx/bin/pxctl host mount encrypted_volume /mnt
+Volume encrypted_volume successfully mounted at /mnt
+```
+
+When using cluster wide secret keys, the secret key does not need to be provided in any of the commands. When no secret key is provided in the pxctl volume commands, PX defaults to using the cluster wide secret key **if set**

--- a/manage/encrypted-volumes.md
+++ b/manage/encrypted-volumes.md
@@ -11,98 +11,28 @@ meta-description: "This guide will give you an overview of how to use the Encryp
 * TOC
 {:toc}
 
-## Encrypted Volumes
-This guide will give you an overview of how to use Encryption feature for Portworx volumes. Under the hood Portworx uses libgcrypt library to interface with the dm-crypt module for creating, accessing and managing encrypted devices. Portworx uses the LUKS format of dm-crypt and AES-256 as the cipher with xts-plain64 as the cipher mode.
-
-All the encrypted volumes are protected by a key. Portworx uses a passphrase as a key to encrypt volumes. It is recommended to store these passphrases in a secure secret store. To know more about the supported secret providers and how to configure them with Portworx, refer the [Setup Secrets Provider](/secrets) page.
-
-## Creating and using encrypted volumes
-
-There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
-
-### Using cluster wide secret key
-Cluster wide secret key is basically a key value pair where the value part is the secret that is used as a passphrase for encrypting volumes. A cluster wide secret key is a common key that can be used to encrypt all your volumes.
-
-__Important: Make sure the cluster wide secret key is set when you are setting up Portworx with one of the supported secret endpoints__
-
-```
-# /opt/pwx/bin/pxctl volume create --secure --size 10 encrypted_volume
-Volume successfully created: 822124500500459627
-# /opt/pwx/bin/pxctl volume list
-ID	      	     		NAME		SIZE	HA SHARED	ENCRYPTED	IO_PRIORITY	SCALE	STATUS
-822124500500459627	 encrypted_volume	10 GiB	1    no yes		LOW		1	up - detached
-```
-
-You can attach and mount the encrypted volume
-
-```
-# /opt/pwx/bin/pxctl host attach encrypted_volume
-Volume successfully attached at: /dev/mapper/pxd-enc822124500500459627
-# /opt/pwx/bin/pxctl host mount encrypted_volume /mnt
-Volume encrypted_volume successfully mounted at /mnt
-```
-
-We do not need to specify a secret key during create or attach of a volume as it will by default use the cluster wide secret key for encryption. However you can specify per volume keys which is explained in the next section.
+{% include secrets/intro.md %}
 
 
-### Using per volume secret keys
-
-You can encrypt volumes using different keys instead of the cluster wide secret key. However you need to specify the key for every create
-and attach commands.
+If you are running in Kubernetes follow [this](/scheduler/kubernetes/encrypted-volumes.html) guide to setup and use encrypted volumes.
 
 
-```
-# /opt/pwx/bin/pxctl volume create --secure --secret_key key1 enc_vol
-Volume successfully created: 374663852714325215
+Based on your configured secret provider select one of the following volume
 
-# docker run --rm -it -v secret_key=key1,name=enc_vol:/mnt busybox
-/ #
+### Vault
 
-# docker run --rm -it --mount src=secret_key=key1?name=enc_vol,dst=/mnt busybox
-/ #
-```
+[Portworx Encrypted volumes with Vault](/manage/secrets/encrypted-volumes-vault.html)
 
-__Important: Make sure secret `key1` exists in the secret endpoint__
+### AWS KMS
 
-## Encrypted Shared Volumes
+[Portworx Encrypted volumes with AWS KMS](/manage/secrets/encrypted-volumes-aws.html)
 
-Encrypted shared volume allows access from multiple nodes to the same
-encrypted volume.
 
-Shared flag can be set while creating the encrypted volume using `--shared`
-It can also be enabled or disabled during run-time using `--shared on/off`.
-Volume must be in detached state to toggle shared flag during run-time.
+### IBM Key Protect
 
-Portworx cluster must be authenticated to access secret store for
-the encryption keys.
-Both cluster wide and per volume secrets are supported. For example, using
-cluster wide secret key:
+[Portworx Encrypted volumes with IBM Key Protect](/manage/secrets/encrypted-volumes-ibm-kp.html)
 
-```
-# pxctl volume create --shared --secure --size 10 encrypted_volume
-Encrypted Shared volume successfully created: 77957787758406722
-# pxctl volume inspect encrypted_volume
-Volume	:  77957787758406722
-Name            	 :  encrypted_volume
-Size            	 :  10 GiB
-Format          	 :  ext4
-HA              	 :  1
-IO Priority     	 :  LOW
-Creation time   	 :  Nov 1 17:22:59 UTC 2018
-Shared          	 :  yes
-Status          	 :  up
-State           	 :  detached
-Attributes      	 :  encrypted
-Reads           	 :  0
-Reads MS        	 :  0
-Bytes Read      	 :  0
-Writes          	 :  0
-Writes MS       	 :  0
-Bytes Written   	 :  0
-IOs in progress 	 :  0
-Bytes used      	 :  131 MiB
-Replica sets on nodes:
-	Set 0
-		Node 		 : 70.0.18.11 (Pool 0)
-Replication Status	 :  Detached
-```
+
+### DCOS Secrets
+
+[Portworx Encrypted volumes DCOS Secrets](/manage/secrets/encrypted-volumes-dcos.html)

--- a/manage/secrets/encrypted-volumes-aws.md
+++ b/manage/secrets/encrypted-volumes-aws.md
@@ -18,7 +18,7 @@ Follow [this](/secrets/portworx-with-aws-kms.html#key-generation-with-aws-kms) g
 
 {% include secrets/per-volume-secret.md %}
 
-__Important: Make sure secret `key1` was generated using the pxctl aws kms helper commands__
+__Important: Make sure secret `key1` was generated using the pxctl AWS KMS helper commands__
 
 ### Using cluster wide secret key
 

--- a/manage/secrets/encrypted-volumes-aws.md
+++ b/manage/secrets/encrypted-volumes-aws.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: "Portworx Encrypted Volumes with AWS KMS"
+keywords: portworx, px-developer, px-enterprise, plugin, install, configure, container, storage, encryption, aws, kms
+meta-description: "This guide will give you an overview of how to use the Encryption feature for Portworx volumes with AWS KMS"
+---
+
+* TOC
+{:toc}
+
+## Creating and using encrypted volumes
+
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+### Using per volume secret keys
+
+Follow [this](/secrets/portworx-with-aws-kms.html#key-generation-with-aws-kms) guide to create secrets in AWK KMS using pxctl.
+
+{% include secrets/per-volume-secret.md %}
+
+__Important: Make sure secret `key1` was generated using the pxctl aws kms helper commands__
+
+### Using cluster wide secret key
+
+Follow [this](/secrets/portworx-with-aws-kms.html#setting-cluster-wide-secret-key) guide to setup cluster wide secret key.
+
+{% include secrets/volume-cluster-wide-secret.md %}
+
+__Important: Make sure the cluster wide secret key is set when you are setting up Portworx with AWS KMS__

--- a/manage/secrets/encrypted-volumes-dcos.md
+++ b/manage/secrets/encrypted-volumes-dcos.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: "Portworx Encrypted Volumes with DCOS Secrets"
+keywords: portworx, px-developer, px-enterprise, plugin, install, configure, container, storage, encryption, dcos, secrets
+meta-description: "This guide will give you an overview of how to use the Encryption feature for Portworx volumes with DCOS Secrets"
+---
+
+* TOC
+{:toc}
+
+## Creating and using encrypted volumes
+
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+### Using per volume secret keys
+
+{% include secrets/per-volume-secret.md %}
+
+__Important: Make sure secret `key1` was set in DCOS Secrets__
+
+### Using cluster wide secret key
+
+Follow [this](/secrets/portworx-with-dcos-secrets.html#setting-cluster-wide-secret-key) guide to setup cluster wide secret key.
+
+{% include secrets/volume-cluster-wide-secret.md %}
+
+__Important: Make sure the cluster wide secret key is set when you are setting up Portworx with DCOS Secrets__

--- a/manage/secrets/encrypted-volumes-ibm-kp.md
+++ b/manage/secrets/encrypted-volumes-ibm-kp.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Portworx Encrypted Volumes with IBM Key Protect"
+keywords: portworx, px-developer, px-enterprise, plugin, install, configure, container, storage, encryption, ibm, key-protect
+meta-description: "This guide will give you an overview of how to use the Encryption feature for Portworx volumes with IBM Key Protect"
+---
+
+* TOC
+{:toc}
+
+## Creating and using encrypted volumes
+
+### Using per volume secret keys
+
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX. Portworx uses IBM Key Protect APIs to generate a unique 256 bit passphrase. This passphrase will be used during encryption and decryption.
+
+To create a volume through pxctl, run the following command
+
+```
+# /opt/pwx/bin/pxctl volume create --secure  enc_vol
+Volume successfully created: 374663852714325215
+
+```
+
+To create a volume through docker, run the following command
+
+```
+# docker volume create --volume-driver pxd secure=true,name=enc_vol
+
+```
+
+To attach and mount an encrypted volume through docker, run the following command
+
+```
+# docker run --rm -it -v secure=true,name=enc_vol:/mnt busybox
+/ #
+```
+
+Note that no `secret_key` needs to be passed in any of the commands.
+
+### Using cluster wide secret key
+
+In this method a default cluster wide secret will be set for the Portworx cluster. Such a secret will be referenced by the user and Portworx as **default** secret. Any PVC request referencing the
+secret name as `default` will use this cluster wide secret as a passphrase to encrypt the volume.
+
+To create a volume using a cluster wide secret through pxctl, run the following command
+
+```
+# pxctl command to create an encrypted volume
+# /opt/pwx/bin/pxctl volume create --secure --secret_key default enc_vol
+Volume successfully created: 374663852714325215
+
+```
+
+To create a volume using a cluster wide secret through docker, run the following command
+
+```
+# docker volume create --volume-driver pxd secret_key=default,name=enc_vol
+
+```
+
+To attach and mount an encrypted volume through docker, run the following command
+
+```
+# docker run --rm -it -v secure=true,secret_key=default,name=enc_vol:/mnt busybox
+/ #
+
+```
+
+Note the `secret_key` is set to the value `default` to indicate PX to use the cluster-wide secret key

--- a/manage/secrets/encrypted-volumes-vault.md
+++ b/manage/secrets/encrypted-volumes-vault.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: "Portworx Encrypted Volumes with Vault"
+keywords: portworx, px-developer, px-enterprise, plugin, install, configure, container, storage, encryption, vault
+meta-description: "This guide will give you an overview of how to use the Encryption feature for Portworx volumes with Vault."
+---
+
+* TOC
+{:toc}
+
+## Creating and using encrypted volumes
+
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+### Using per volume secret keys
+
+{% include secrets/per-volume-secret.md %}
+
+__Important: Make sure secret `key1` exists in Vault__
+
+### Using cluster wide secret key
+
+Follow [this](/secrets/portworx-with-vault.html#setting-cluster-wide-secret-key) guide to setup cluster wide secret key.
+
+{% include secrets/volume-cluster-wide-secret.md %}
+
+__Important: Make sure the cluster wide secret key is set when you are setting up Portworx with Vault__

--- a/scheduler/kubernetes/encrypted-pvc-awskms.md
+++ b/scheduler/kubernetes/encrypted-pvc-awskms.md
@@ -10,9 +10,7 @@ meta-description: "This guide is a step-by-step tutorial on how to provision enc
 
 >**Note:**<br/>Supported from PX Enterprise 1.4 onwards
 
-There are two way in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
-
-There are two way in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
 
 ### Encryption using Storage Class
 
@@ -36,4 +34,4 @@ In this method, each PVC can be encrypted with its own secret key.
 
 {% include /secrets/k8s/other-providers-pvc-encryption.md  %}
 
-__Important: Make sure secret `your_secret_key` was generated using the pxctl aws kms helper commands__
+__Important: Make sure secret `your_secret_key` was generated using the pxctl AWS KMS helper commands__

--- a/scheduler/kubernetes/encrypted-pvc-awskms.md
+++ b/scheduler/kubernetes/encrypted-pvc-awskms.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: "Encrypting PVCs with AWS KMS"
+keywords: portworx, container, kubernetes, storage, k8s, flexvol, pv, persistent disk, encryption, pvc, aws, kms
+meta-description: "This guide is a step-by-step tutorial on how to provision encrypted PVCs with Portworx configured with AWS KMS"
+---
+
+* TOC
+{:toc}
+
+>**Note:**<br/>Supported from PX Enterprise 1.4 onwards
+
+There are two way in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+There are two way in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+### Encryption using Storage Class
+
+In this method, PX will use the cluster wide secret key to encrypt PVCs.
+
+#### Step 1: Set a cluster wide secret
+
+Follow [this](/secrets/portworx-with-aws-kms.html#setting-cluster-wide-secret-key) guide to setup cluster wide secret key.
+
+{% include /secrets/k8s/storage-class-encryption.md %}
+
+### Encryption using PVC annotations
+
+In this method, each PVC can be encrypted with its own secret key.
+
+#### Step 1: Create a Storage Class
+
+{% include /secrets/k8s/enc-storage-class-spec.md %}
+
+#### Step 2: Create a PVC with annotation
+
+{% include /secrets/k8s/other-providers-pvc-encryption.md  %}
+
+__Important: Make sure secret `your_secret_key` was generated using the pxctl aws kms helper commands__

--- a/scheduler/kubernetes/encrypted-pvc-ibm-kp.md
+++ b/scheduler/kubernetes/encrypted-pvc-ibm-kp.md
@@ -1,0 +1,93 @@
+---
+layout: page
+title: "Encryption using PVC with IBM Key Protect"
+keywords: portworx, container, kubernetes, storage, k8s, flexvol, pv, persistent disk, encryption, pvc
+meta-description: "This guide is a step-by-step tutorial on how to provision encrypted volumes using PVC annotations."
+---
+
+* TOC
+{:toc}
+
+>**Note:**<br/>Supported from PX Enterprise 1.7 onwards
+
+### Encryption using per volume secrets
+
+In this method each volume will use its own unique passphrase to encrypt the volume. Portworx uses IBM Key Protect APIs to generate a unique 256 bit passphrase. This passphrase will be used during encryption and decryption.
+
+#### Step 1: Create a Storage Class
+
+{% include /secrets/k8s/enc-storage-class-spec.md %}
+
+#### Step 2: Create a Persistent Volume Claim
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-data
+  annotations:
+    volume.beta.kubernetes.io/storage-class: px-secure-sc
+spec:
+  storageClassName: px-mysql-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+
+```
+
+If you do not want to specify the `secure` flag in the storage class, but you want to encrypt the PVC using that Storage Class, then create the PVC as below
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: secure-pvc
+  annotations:
+    px/secure: "true"
+spec:
+  storageClassName: portworx-sc
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```
+Note the `px/secure: "true"` annotation on the PVC object.
+
+### Encryption using cluster wide secret
+
+In this method a default cluster wide secret will be set for the Portworx cluster. Such a secret will be referenced by the user and Portworx as **default** secret. Any PVC request referencing the secret name as `default` will use this cluster wide secret as a passphrase to encrypt the volume.
+
+#### Step 1: Set the cluster wide secret key
+
+{% include secrets/set-ibm-cluster-wide-secret.md %}
+
+#### Step 2: Create a Storage Class
+
+{% include /secrets/k8s/enc-storage-class-spec.md %}
+
+#### Step 3: Create a Persistent Volume Claim
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-data
+  annotations:
+    px/secret-name: default
+    volume.beta.kubernetes.io/storage-class: px-secure-sc
+spec:
+  storageClassName: px-mysql-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+
+```
+
+Take a note of the annotation `px/secret-name: default`. This specific annotation indicates Portworx to use the default secret to encrypt the volume. In this case it will **NOT**  create a new passphrase for this volume and NOT use per volume encryption. If the annotation is not provided then Portworx will use the per volume encryption workflow as described in the previous section.
+
+Again, if your Storage Class does not have the `secure` flag set, but you want to encrypt the PVC using the same Storage Class, then add the annotation `px/secure: "true"` to the above PVC.

--- a/scheduler/kubernetes/encrypted-pvc-vault.md
+++ b/scheduler/kubernetes/encrypted-pvc-vault.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: "Encrypting PVCs with Vault"
+keywords: portworx, container, kubernetes, storage, k8s, flexvol, pv, persistent disk, encryption, pvc, vault
+meta-description: "This guide is a step-by-step tutorial on how to provision encrypted PVCs with Portworx configured with Vault"
+---
+
+* TOC
+{:toc}
+
+>**Note:**<br/>Supported from PX Enterprise 1.4 onwards
+
+There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to PX.
+
+### Encryption using Storage Class
+
+In this method, PX will use the cluster wide secret key to encrypt PVCs.
+
+#### Step 1: Set a cluster wide secret
+
+Follow [this](/secrets/portworx-with-vault.html#setting-cluster-wide-secret-key) guide to setup cluster wide secret key if not already set.
+
+{% include /secrets/k8s/storage-class-encryption.md %}
+
+### Encryption using PVC annotations
+
+In this method, each PVC can be encrypted with its own secret key.
+
+#### Step 1: Create a Storage Class
+
+{% include /secrets/k8s/enc-storage-class-spec.md %}
+
+#### Step 2: Create a PVC with annotation
+
+{% include /secrets/k8s/other-providers-pvc-encryption.md  %}
+
+__Important: Make sure secret `your_secret_key` exists in Vault__

--- a/scheduler/kubernetes/encrypted-volumes.md
+++ b/scheduler/kubernetes/encrypted-volumes.md
@@ -9,10 +9,23 @@ meta-description: "Looking to use a encrypted volume with Kubernetes? Follow thi
 * TOC
 {:toc}
 
-This document describes how to provision an encrypted volume using Kubernetes and Portworx. For more information on encryption refer the [Encrypted Volumes page](/manage/encrypted-volumes.html).
+{% include secrets/intro.md %}
 
-Before you start using PVC encryption, you need to setup a secrets provider to store your secret keys and configure Portworx to use it. Refer the [Setup Secrets Provider](/secrets) page for more details on configuring various secret providers with Portworx.
+Based on your configured secret provider select one of the following volume encryption guides:
 
-There are a couple of ways you can create an encrypted Portworx volume in Kubernetes:
+### Kubernetes Secrets
+
 1. [Encryption using StorageClass](/scheduler/kubernetes/storage-class-encryption.html)
 2. [Encryption using PVC](/scheduler/kubernetes/pvc-encryption.html)
+
+### Vault
+
+[Encrypting PVCs with Vault](/scheduler/kubernetes/encrypted-pvc-vault.html)
+
+### AWS KMS
+
+[Encrypting PVCs with AWS KMS](/scheduler/kubernetes/encrypted-pvc-awskms.html)
+
+### IBM Key Protect
+
+[Encrypting PVCs with IBM Key Protect](/scheduler/kubernetes/encrypted-pvc-ibm-kp.html)

--- a/scheduler/kubernetes/pvc-encryption.md
+++ b/scheduler/kubernetes/pvc-encryption.md
@@ -109,19 +109,4 @@ EOF
 
 #### Other secrets provider
 Other secrets providers like Vault, AWS KMS, DC/OS, etc do not have namespaces. Hence, you need only `px/secret-name` annotation to specify the key to be used for encryption.
-```yaml
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: secure-mysql-pvc
-  annotations:
-    px/secret-name: your-secret-key
-spec:
-  storageClassName: portworx-sc
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
-```
 Portworx will look for `your-secret-key` in the secret store and use it's value to encrypt the above PVC.

--- a/scheduler/kubernetes/pvc-encryption.md
+++ b/scheduler/kubernetes/pvc-encryption.md
@@ -106,7 +106,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 EOF
 ```
-
-#### Other secrets provider
-Other secrets providers like Vault, AWS KMS, DC/OS, etc do not have namespaces. Hence, you need only `px/secret-name` annotation to specify the key to be used for encryption.
-Portworx will look for `your-secret-key` in the secret store and use it's value to encrypt the above PVC.

--- a/scheduler/kubernetes/set-cluster-wide-secret.md
+++ b/scheduler/kubernetes/set-cluster-wide-secret.md
@@ -1,9 +1,6 @@
 #### Step 1: Create cluster wide secret key
 A cluster wide secret key is a common key that points to a secret value/passphrase which can be used to encrypt all your volumes.
 
-Below are the 2 options for creating the cluster wide secret key:
-
-##### Option 1: Kubernetes Secrets
 Create a cluster wide secret in Kubernetes, if not already created:
 ```bash
 $ kubectl -n portworx create secret generic px-vol-encryption \
@@ -17,6 +14,3 @@ $ PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='{.items
 $ kubectl exec $PX_POD -n kube-system -- /opt/pwx/bin/pxctl secrets set-cluster-key \
   --secret cluster-wide-secret-key
 ```
-
-##### Option 2: Other secrets provider
-Similar to Kubernetes secrets, you can set the cluster wide secret key in the secrets provider that you have configured. Refer to the 'Setting cluster wide secret key' section under the respective [secrets provider integration](/secrets).

--- a/scheduler/kubernetes/storage-class-encryption.md
+++ b/scheduler/kubernetes/storage-class-encryption.md
@@ -9,40 +9,4 @@ Using a Storage Class parameter, you can tell Portworx to encrypt all PVCs creat
 
 {% include_relative set-cluster-wide-secret.md %}
 
-#### Step 2: Create a StorageClass
-Create a storage class with `secure` parameter set to `true`.
-```yaml
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: px-secure-sc
-provisioner: kubernetes.io/portworx-volume
-parameters:
-  secure: "true"
-  repl: "3"
-```
-
-#### Step 3: Create Persistent Volume Claim
-Create a PVC that uses the above `px-secure-sc` storage class.
-```yaml
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: secure-pvc
-spec:
-  storageClassName: px-secure-sc
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
-```
-
-#### Step 4: Verify the volume
-Once the PVC has been created, verify the volume created in Portworx is encrypted.
-```
-# PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='{.items[0].metadata.name}')
-# kubectl exec $PX_POD -n kube-system -- /opt/pwx/bin/pxctl volume list
-ID                 NAME                                      ...  ENCRYPTED  ...
-10852605918962284  pvc-5a885584-44ca-11e8-a17b-080027ee1df7  ...  yes        ...
-```
+{% include secrets/k8s/storage-class-encryption.md %}

--- a/secrets/portworx-with-ibm-kp.md
+++ b/secrets/portworx-with-ibm-kp.md
@@ -1,0 +1,191 @@
+---
+layout: page
+title: "Portworx with IBM Key Protect"
+sidebar: home_sidebar
+meta-description: "Portworx can integrate with IBM Key Protect to store your encryption keys/secrets. This guide will get a Portworx cluster connected to an IBM Key Protect Service"
+---
+
+* TOC
+{:toc}
+
+Portworx integrates with IBM Key Protect to store your encryption keys/secrets and credentials. This guide will help configure Portworx with IBM Key Protect. IBM Key Protect can be used to store Portworx secrets for Volume Encryption and Cloud Credentials.
+
+Portworx requires the following IBM Key Protect credentials to use its APIs
+
+- Service Instance ID [IBM_SERVICE_INSTANCE_ID]
+
+The Instance ID of the IBM Key Protect service can be found by running the following command
+
+```
+$ ibmcloud resource service-instance <name of your key protect service>
+crn:v1:bluemix:public:kms:us-south:a/fb474855a3e76c1ceblahf57e0f1a9f:0647c737-906d-blah-8a68-2c187e11b29b::
+```
+The ID from the above CRN is `0647c737-906d-blah-8a68-2c187e11b29b`
+
+
+- Service API Key [IBM_SERVICE_API_KEY]
+
+Follow [this](https://console.bluemix.net/docs/services/key-protect/access-api.html#access-api) IBM document to retrieve the API Key.
+
+- Customer Root Key [IBM_CUSTOMER_ROOT_KEY]
+
+Follow [this](https://console.bluemix.net/docs/services/key-protect/index.html#create-keys) IBM document to create a Customer Root Key
+
+- Base URL [IBM_BASE_URL]
+
+BaseURL specifies the URL where your Key Protect instance resides. It is region specific. Default value which will be used is: https://keyprotect.us-south.bluemix.net
+
+- Token URL [IBM_TOKEN_URL]
+
+Default value which will be used is: https://iam.bluemix.net/oidc/token
+
+Based on your installation type use the following methods to provide these credentials to Portworx.
+
+## For Kubernetes Users
+
+### Step 1: Provide IBM Key Protect credentials to Portworx.
+
+Portworx reads the IBM credentials required to authenticate with IBM Key Protect through a Kubernetes secret. Create a Kubernetes secret with the name `px-ibm` in the `portworx` namespace. Following is an example kubernetes secret spec
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: px-ibm
+  namespace: portworx
+type: Opaque
+data:
+  IBM_SERVICE_API_KEY: RnVWZ1JiSndxVHl5VXblah1TWU5paEdHQzhRUVAwVDVMN1NSSHA5Z2VNa2k=
+  IBM_INSTANCE_ID: NGZkNDA1Y2QtODBmZC00MGblahE0ZWQtZDdhOTFiMTdiZjEx
+  IBM_CUSTOMER_ROOT_KEY: MGYxNGExNzMtODE2blahN2Q3LTg1ZGYtY2M3ZWI5YmYxNzRj
+
+```
+Portworx is going to look for this secret with name `px-ibm` under the `portworx` namespace. While installing Portworx it creates a kubernetes role binding which grants access to reading kubernetes secrets only from the `portworx` namespace.
+
+### Step 2: Set up IBM Key Protect as the secrets provider for Portworx.
+
+#### New installation
+
+##### Using helm chart
+
+While deploying Portworx using helm chart on an IKS cluster, by default Portworx is configured to use IBM Key Protect as a secrets provider. Follow [these instructions](https://github.com/portworx/helm/blob/master/charts/portworx/README.md) to install the helm chart.
+
+In an non IKS cluster, set the `secretType` as `ibm-kp` in the helm chart's values.yml configuration file.
+
+##### Using Portworx Spec Generator
+
+When generating the [Portworx Kubernetes spec file](https://install.portworx.com/), select `IBM Key Protect` from the "Secrets type" list. For more details on how to generate Portworx spec for Kubernetes, refer instructions on [Deploy Portworx on Kubernetes](/scheduler/kubernetes).
+
+#### Existing installation
+
+For an existing Portworx cluster follow these steps to configure IBM Key Protect as the secrets provider
+
+##### Step 2a: Add Permissions to access kubernetes secrets
+Portworx needs permissions to access the `px-ibm` secret created in Step 1. The following Kubernetes spec grants portworx access to all the secrets defined under the `portworx` namespace
+
+```yaml
+cat <<EOF | kubectl apply -f -
+# Namespace to store credentials
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portworx
+---
+# Role to access secrets under portworx namespace only
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: px-role
+  namespace: portworx
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "update", "patch"]
+---
+# Allow portworx service account to access the secrets under the portworx namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: px-role-binding
+  namespace: portworx
+subjects:
+- kind: ServiceAccount
+  name: px-account
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: px-role
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+
+##### Step 2b: Update the config.json
+After ensuring the `portworx` namespace and the required permissions are present, you will have to update the `/etc/pwx/config.json` to start using IBM Key Protect. Add the `secret_type` fields in the `secret` section to the `/etc/pwx/config.json` on each node in the cluster:
+```json
+{
+    "clusterid": "",
+    "secret": {
+        "secret_type": "ibm-kp",
+    },
+    ...
+}
+```
+
+##### Step 2c: Edit the Portworx Daemonset
+
+Edit the Portworx daemonset `secret_type` field to `ibm-kp`, so that all the new Portworx nodes will also start using IBM Key Protect. There is no need to change the *config.json* for the new nodes if the daemonset is edited
+
+```
+# kubectl edit daemonset portworx -n kube-system
+```
+Add the `"-secret_type", "ibm-kp"` arguments to the `portworx` container in the daemonset. It should look something like this:
+
+```yaml
+  containers:
+  - args:
+    - -c
+    - testclusterid
+    - -s
+    - /dev/sdb
+    - -x
+    - kubernetes
+    - -secret_type
+    - ibm-kp
+    name: portworx
+```
+Editing the daemonset will also restart all the Portworx pods, which will consume the modified *config.json*.
+
+## Other users
+
+### Step 1: Provide IBM Key Protect credentials to Portworx.
+
+Provide the following IBM credentials (key value pairs) as environment variables to Portworx
+
+- [Required] IBM_SERVICE_INSTANCE_ID=[service_instance_id]
+
+- [Required] IBM_SERVICE_API_KEY=[service_api_key]
+
+- [Required] IBM_CUSTOMER_ROOT_KEY=[customer_root_key]
+
+- [Optional] IBM_BASE_URL=[base_url] → only required if the instance is in a different region
+
+- [Optional] IBM_TOKEN_URL=[token_url] → only required if the different than the default token url
+
+### Step 2: Set up IBM Key Protect as the secrets provider for Portworx.
+
+#### New installation
+
+While installing Portworx set the input argument `-secret_type` to `ibm-kp`.
+
+#### Existing installation
+
+Update the `/etc/pwx/config.json` on all the nodes to start using IBM Key Protect. Add the `secret_type` fields in the `secret` section to the `/etc/pwx/config.json` on each node in the cluster:
+```json
+{
+    "clusterid": "",
+    "secret": {
+        "secret_type": "ibm-kp",
+    },
+    ...
+}
+```

--- a/secrets/portworx-with-ibm-kp.md
+++ b/secrets/portworx-with-ibm-kp.md
@@ -131,6 +131,8 @@ After ensuring the `portworx` namespace and the required permissions are present
 }
 ```
 
+Once the `/etc/pwx/config.json` is updated, restart PX for the changes to take effect.
+
 ##### Step 2c: Edit the Portworx Daemonset
 
 Edit the Portworx daemonset `secret_type` field to `ibm-kp`, so that all the new Portworx nodes will also start using IBM Key Protect. There is no need to change the *config.json* for the new nodes if the daemonset is edited


### PR DESCRIPTION
Modified the way secret docs are organized. Made some changes aligning with the new doc layout where it is more interactive. 
- Move common secrets docs to _includes.
- Add a new doc for IBM Key Protect
- Add a landing page for Encrypted volumes in these sections
  - Manage Encrypted Volumes
  - Create Encrypted Volumes in Kubernetes